### PR TITLE
fix: ignore Copilot VK_F23 signal on Windows

### DIFF
--- a/src-tauri/src/plugins/hotkey_listener.rs
+++ b/src-tauri/src/plugins/hotkey_listener.rs
@@ -1111,7 +1111,7 @@ mod windows_hook {
         if n_code >= 0 {
             if let Some(ctx) = CONTEXT.get() {
                 let kbd = *(l_param.0 as *const KBDLLHOOKSTRUCT);
-                // Ignore Copilot's dedicated VK_F23 signal to avoid interfering with QuickFill.
+                // Ignore Copilot's dedicated VK_F23 signal to avoid interfering with Quick View.
                 if kbd.vkCode == VK_F23 {
                     return CallNextHookEx(None, n_code, w_param, l_param);
                 }

--- a/src-tauri/src/plugins/hotkey_listener.rs
+++ b/src-tauri/src/plugins/hotkey_listener.rs
@@ -930,6 +930,7 @@ mod windows_hook {
     const VK_LMENU: u32 = 0xA4;
     const VK_RMENU: u32 = 0xA5;
     const VK_ESCAPE: u32 = 0x1B;
+    const VK_F23: u32 = 0x86;
 
     // Windows modifier VK codes for combo detection
     const VK_LWIN: u32 = 0x5B;
@@ -1110,6 +1111,10 @@ mod windows_hook {
         if n_code >= 0 {
             if let Some(ctx) = CONTEXT.get() {
                 let kbd = *(l_param.0 as *const KBDLLHOOKSTRUCT);
+                // Ignore Copilot's dedicated VK_F23 signal to avoid interfering with QuickFill.
+                if kbd.vkCode == VK_F23 {
+                    return CallNextHookEx(None, n_code, w_param, l_param);
+                }
                 let w = w_param.0 as u32;
 
                 let is_key_down = w == WM_KEYDOWN || w == WM_SYSKEYDOWN;


### PR DESCRIPTION
## Summary
- Ignore Copilot's dedicated Windows VK_F23 signal in the low-level keyboard hook
- Pass VK_F23 through immediately via CallNextHookEx to avoid interfering with Copilot Quick View
- Extract VK_F23 into a named constant instead of using a magic number

## Notes
- This is Windows-only and does not affect macOS behavior.
- This intentionally prevents VK_F23 from being used as a SayIt custom hotkey on Windows because it is reserved here for Copilot compatibility.

## Validation
- Reviewed the Windows hook code path on macOS
- Ran git diff --check
- VS Code diagnostics showed no errors for the modified file
- Could not run Windows runtime/compiler validation locally because this environment is macOS and does not have the required Windows toolchain