### PR TITLE
feat(dictionary): 字典單檔匯出／匯入（含從 Typeless 遷移）

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -255,7 +255,17 @@
     "description": "Dictionary terms are provided to the AI during speech recognition to improve accuracy for proper nouns and technical terms.",
     "weightDescription": "During each speech recognition, the top {limit} terms by weight are included in the AI recognition prompt. When the AI detects you repeatedly correcting the same term, its weight increases automatically.",
     "noAiSuggestions": "No AI suggestions yet. Enable Smart Dictionary Learning to auto-learn new terms",
-    "aiTermCount": "{count} terms"
+    "aiTermCount": "{count} terms",
+    "export": "Export",
+    "import": "Import",
+    "exportSuccess": "Exported {count} terms",
+    "exportEmpty": "No terms to export",
+    "importSuccess": "Import complete: {added} added, {merged} merged, {skipped} skipped",
+    "importEmpty": "No importable terms found in the file",
+    "importTooLarge": "File is too large to import",
+    "importInvalidFile": "Unrecognized file format",
+    "importFailed": "Import failed: {error}",
+    "transferHint": "Export your dictionary to a single file and import it on another device. Import also accepts a plain .txt/.csv file (one term per line) — handy for migrating from tools like Typeless."
   },
   "accessibility": {
     "title": "Accessibility Permission Required",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -255,7 +255,17 @@
     "description": "辞書の用語は音声認識時に AI に提供され、固有名詞や技術用語の認識精度を向上させます。",
     "weightDescription": "音声認識のたびに、重みが最も高い上位 {limit} 語が AI 認識プロンプトに含まれます。同じ修正が繰り返し検出されると、その用語の重みが自動的に増加します。",
     "noAiSuggestions": "AI 推奨の用語はまだありません。スマート辞書学習を有効にすると自動学習されます",
-    "aiTermCount": "{count} 語"
+    "aiTermCount": "{count} 語",
+    "export": "エクスポート",
+    "import": "インポート",
+    "exportSuccess": "{count} 語をエクスポートしました",
+    "exportEmpty": "エクスポートする語がありません",
+    "importSuccess": "インポート完了：追加 {added}、統合 {merged}、スキップ {skipped}",
+    "importEmpty": "ファイルにインポート可能な語がありません",
+    "importTooLarge": "ファイルが大きすぎてインポートできません",
+    "importInvalidFile": "認識できないファイル形式です",
+    "importFailed": "インポートに失敗しました：{error}",
+    "transferHint": "辞書を単一ファイルにエクスポートし、別のデバイスでインポートできます。インポートはプレーンテキスト .txt/.csv（1行1語）にも対応しており、Typeless などからの移行に便利です。"
   },
   "accessibility": {
     "title": "アクセシビリティ権限が必要です",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -255,7 +255,17 @@
     "description": "사전 용어는 음성 인식 시 AI에 제공되어 고유명사와 기술 용어의 인식 정확도를 높입니다.",
     "weightDescription": "음성 인식 시 가중치가 가장 높은 상위 {limit}개 용어가 AI 인식 프롬프트에 포함됩니다. 동일한 수정이 반복 감지되면 해당 용어의 가중치가 자동으로 증가합니다.",
     "noAiSuggestions": "아직 AI 추천 용어가 없습니다. 스마트 사전 학습을 활성화하면 자동으로 학습됩니다",
-    "aiTermCount": "{count}개 용어"
+    "aiTermCount": "{count}개 용어",
+    "export": "내보내기",
+    "import": "가져오기",
+    "exportSuccess": "{count}개 용어를 내보냈습니다",
+    "exportEmpty": "내보낼 용어가 없습니다",
+    "importSuccess": "가져오기 완료: 추가 {added}, 병합 {merged}, 건너뜀 {skipped}",
+    "importEmpty": "파일에 가져올 용어가 없습니다",
+    "importTooLarge": "파일이 너무 커서 가져올 수 없습니다",
+    "importInvalidFile": "인식할 수 없는 파일 형식입니다",
+    "importFailed": "가져오기 실패: {error}",
+    "transferHint": "사전을 단일 파일로 내보내 다른 기기에서 가져올 수 있습니다. 가져오기는 일반 텍스트 .txt/.csv(한 줄에 한 단어)도 지원하여 Typeless 등에서 이전할 때 편리합니다."
   },
   "accessibility": {
     "title": "손쉬운 사용 권한 필요",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -255,7 +255,17 @@
     "description": "字典词汇会在语音识别时提供给 AI，提升专有名词与术语的识别准确度。",
     "weightDescription": "每次语音识别时，系统会将权重最高的前 {limit} 个词汇加入 AI 识别提示。当 AI 检测到你重复修正同一个词时，该词的权重会自动提升。",
     "noAiSuggestions": "暂无 AI 推荐词汇，启用智能字典学习后系统会自动学习",
-    "aiTermCount": "{count} 个词"
+    "aiTermCount": "{count} 个词",
+    "export": "导出",
+    "import": "导入",
+    "exportSuccess": "已导出 {count} 个词",
+    "exportEmpty": "没有可导出的词",
+    "importSuccess": "导入完成：新增 {added}、合并 {merged}、跳过 {skipped}",
+    "importEmpty": "文件中没有可导入的词",
+    "importTooLarge": "文件太大，无法导入",
+    "importInvalidFile": "无法识别的文件格式",
+    "importFailed": "导入失败：{error}",
+    "transferHint": "可将词典导出为单一文件，在另一台设备导入。导入也支持纯文本 .txt/.csv（一行一个词），方便从 Typeless 等工具迁移。"
   },
   "accessibility": {
     "title": "需要辅助使用权限",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -255,7 +255,17 @@
     "description": "字典詞彙會在語音辨識時提供給 AI，提升專有名詞與術語的辨識準確度。",
     "weightDescription": "每次語音辨識時，系統會將權重最高的前 {limit} 個詞彙加入 AI 辨識提示。當 AI 偵測到你重複修正同一個詞時，該詞的權重會自動提升。",
     "noAiSuggestions": "尚無 AI 推薦詞彙，啟用智慧字典學習後系統會自動學習",
-    "aiTermCount": "{count} 個詞"
+    "aiTermCount": "{count} 個詞",
+    "export": "匯出",
+    "import": "匯入",
+    "exportSuccess": "已匯出 {count} 個詞",
+    "exportEmpty": "沒有可匯出的詞",
+    "importSuccess": "匯入完成：新增 {added}、合併 {merged}、略過 {skipped}",
+    "importEmpty": "檔案中沒有可匯入的詞",
+    "importTooLarge": "檔案太大，無法匯入",
+    "importInvalidFile": "無法辨識的檔案格式",
+    "importFailed": "匯入失敗：{error}",
+    "transferHint": "可將字典匯出成單一檔案，在另一台裝置匯入。匯入也支援純文字 .txt/.csv（一行一個詞），方便從 Typeless 等工具遷移。"
   },
   "accessibility": {
     "title": "需要輔助使用權限",

--- a/src/lib/vocabularyTransfer.ts
+++ b/src/lib/vocabularyTransfer.ts
@@ -1,0 +1,140 @@
+import type {
+  ImportedTerm,
+  VocabularyExportEntry,
+  VocabularyExportFile,
+  VocabularySource,
+} from "../types/vocabulary";
+
+export const EXPORT_FORMAT = "sayit-dictionary" as const;
+export const EXPORT_VERSION = 1 as const;
+
+/** 單一詞條長度上限，避免匯入超大字串塞爆 DB */
+export const MAX_TERM_LENGTH = 100;
+/** 匯入檔案大小上限（位元組），避免一次塞入過大檔案 */
+export const MAX_IMPORT_FILE_BYTES = 2 * 1024 * 1024;
+
+const VALID_SOURCES: VocabularySource[] = ["manual", "ai"];
+
+function normalizeWeight(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return 1;
+  const int = Math.floor(n);
+  return int < 1 ? 1 : int;
+}
+
+function normalizeSource(value: unknown): VocabularySource {
+  return VALID_SOURCES.includes(value as VocabularySource)
+    ? (value as VocabularySource)
+    : "manual";
+}
+
+function normalizeTerm(value: unknown): string {
+  if (typeof value !== "string") return "";
+  // 去除前後空白與換行；折疊內部多餘空白
+  return value.trim().replace(/\s+/g, " ").slice(0, MAX_TERM_LENGTH);
+}
+
+/**
+ * 將詞條陣列去重（以小寫比對，保留先出現者）。
+ * 與 DB 的 UNIQUE(term) 大小寫不敏感比對行為一致（store 端亦以 lower-case 比對）。
+ */
+function dedupe(entries: ImportedTerm[]): ImportedTerm[] {
+  const seen = new Set<string>();
+  const result: ImportedTerm[] = [];
+  for (const entry of entries) {
+    const key = entry.term.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(entry);
+  }
+  return result;
+}
+
+/** 建立可序列化的匯出物件 */
+export function buildExportFile(
+  entries: VocabularyExportEntry[],
+  exportedAt: string,
+): VocabularyExportFile {
+  return {
+    format: EXPORT_FORMAT,
+    version: EXPORT_VERSION,
+    exportedAt,
+    terms: entries.map((e) => ({
+      term: e.term,
+      weight: normalizeWeight(e.weight),
+      source: normalizeSource(e.source),
+    })),
+  };
+}
+
+/** 序列化為帶縮排的 JSON 字串 */
+export function serializeExport(
+  entries: VocabularyExportEntry[],
+  exportedAt: string,
+): string {
+  return JSON.stringify(buildExportFile(entries, exportedAt), null, 2);
+}
+
+/** 解析 SayIt JSON 匯出檔，回傳正規化詞條（容錯：忽略無效詞條） */
+function parseSayItJson(content: string): ImportedTerm[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new Error("INVALID_JSON");
+  }
+
+  const terms = (parsed as Partial<VocabularyExportFile> | null)?.terms;
+  if (!Array.isArray(terms)) {
+    throw new Error("INVALID_FORMAT");
+  }
+
+  const result: ImportedTerm[] = [];
+  for (const raw of terms) {
+    const term = normalizeTerm((raw as VocabularyExportEntry)?.term);
+    if (!term) continue;
+    result.push({
+      term,
+      weight: normalizeWeight((raw as VocabularyExportEntry)?.weight),
+      source: normalizeSource((raw as VocabularyExportEntry)?.source),
+    });
+  }
+  return result;
+}
+
+/**
+ * 解析純文字 / CSV：一行一個詞，遇逗號時取第一欄。
+ * 用於從 Typeless 等沒有匯出功能的工具遷移 —— 使用者自行整理成文字檔即可。
+ * 所有詞條以 source='manual'、weight=1 匯入。
+ */
+function parsePlainText(content: string): ImportedTerm[] {
+  const result: ImportedTerm[] = [];
+  for (const line of content.split(/\r?\n/)) {
+    // 取第一欄（支援 "念法,正確寫法" 這類兩欄資料：SayIt 只存詞條本身）
+    const firstField = line.split(",")[0];
+    const term = normalizeTerm(firstField);
+    if (!term) continue;
+    result.push({ term, weight: 1, source: "manual" });
+  }
+  return result;
+}
+
+/** 內容看起來像 JSON 物件 */
+function looksLikeJson(content: string): boolean {
+  return content.trimStart().startsWith("{");
+}
+
+/**
+ * 依檔名與內容判斷格式並解析。
+ * - .json 或內容像 JSON → 當作 SayIt 匯出檔
+ * - 其他（.txt / .csv / 純文字）→ 寬鬆純文字匯入
+ * 回傳去重後的詞條陣列。
+ */
+export function parseImportContent(
+  filename: string,
+  content: string,
+): ImportedTerm[] {
+  const isJson = /\.json$/i.test(filename) || looksLikeJson(content);
+  const entries = isJson ? parseSayItJson(content) : parsePlainText(content);
+  return dedupe(entries);
+}

--- a/src/stores/useVocabularyStore.ts
+++ b/src/stores/useVocabularyStore.ts
@@ -4,7 +4,13 @@ import { getDatabase } from "../lib/database";
 import { extractErrorMessage } from "../lib/errorUtils";
 import { captureError } from "../lib/sentry";
 import { emitEvent, VOCABULARY_CHANGED } from "../composables/useTauriEvents";
-import type { VocabularyEntry, VocabularySource } from "../types/vocabulary";
+import type {
+  ImportedTerm,
+  ImportResult,
+  VocabularyEntry,
+  VocabularyExportEntry,
+  VocabularySource,
+} from "../types/vocabulary";
 import type { VocabularyChangedPayload } from "../types/events";
 import i18n from "../i18n";
 
@@ -168,6 +174,92 @@ export const useVocabularyStore = defineStore("vocabulary", () => {
     }
   }
 
+  /** 取得所有詞條，供匯出使用（不含 id / createdAt） */
+  async function exportEntries(): Promise<VocabularyExportEntry[]> {
+    const db = getDatabase();
+    const rows = await db.select<RawVocabularyRow[]>(
+      "SELECT term, weight, source FROM vocabulary ORDER BY weight DESC, created_at DESC",
+    );
+    return rows.map((row) => ({
+      term: row.term,
+      weight: row.weight,
+      source: row.source as VocabularySource,
+    }));
+  }
+
+  /**
+   * 批次匯入詞條，以單一交易寫入。合併策略（term 以小寫比對）：
+   * - 不存在 → 新增（added）
+   * - 已存在且匯入 weight 較大 → 更新為較大值（merged）
+   * - 已存在且 weight 未較大 → 略過（skipped）
+   */
+  async function importEntries(
+    entries: ImportedTerm[],
+  ): Promise<ImportResult> {
+    const result: ImportResult = { added: 0, merged: 0, skipped: 0 };
+    if (entries.length === 0) return result;
+
+    const db = getDatabase();
+
+    // 建立現有詞條索引（小寫 term → { id, weight }）
+    const existingRows = await db.select<
+      { id: string; term: string; weight: number }[]
+    >("SELECT id, term, weight FROM vocabulary");
+    const existingByTerm = new Map<string, { id: string; weight: number }>();
+    for (const row of existingRows) {
+      existingByTerm.set(row.term.trim().toLowerCase(), {
+        id: row.id,
+        weight: row.weight,
+      });
+    }
+
+    try {
+      await db.execute("BEGIN TRANSACTION");
+      for (const entry of entries) {
+        const key = entry.term.toLowerCase();
+        const existing = existingByTerm.get(key);
+        if (!existing) {
+          const id = crypto.randomUUID();
+          await db.execute(
+            "INSERT INTO vocabulary (id, term, weight, source) VALUES ($1, $2, $3, $4)",
+            [id, entry.term, entry.weight, entry.source],
+          );
+          // 同次匯入若有重複（理論上已去重）也視為已存在
+          existingByTerm.set(key, { id, weight: entry.weight });
+          result.added += 1;
+        } else if (entry.weight > existing.weight) {
+          await db.execute(
+            "UPDATE vocabulary SET weight = $1 WHERE id = $2",
+            [entry.weight, existing.id],
+          );
+          existing.weight = entry.weight;
+          result.merged += 1;
+        } else {
+          result.skipped += 1;
+        }
+      }
+      await db.execute("COMMIT");
+    } catch (error) {
+      try {
+        await db.execute("ROLLBACK");
+      } catch {
+        // 忽略 rollback 失敗
+      }
+      console.error(
+        `[vocabulary-store] importEntries failed: ${extractErrorMessage(error)}`,
+      );
+      captureError(error, { source: "vocabulary", step: "import" });
+      throw error;
+    }
+
+    await fetchTermList();
+    void emitEvent(VOCABULARY_CHANGED, {
+      action: "added",
+      term: "",
+    } satisfies VocabularyChangedPayload);
+    return result;
+  }
+
   async function getTopTermListByWeight(limit: number): Promise<string[]> {
     try {
       const db = getDatabase();
@@ -198,5 +290,7 @@ export const useVocabularyStore = defineStore("vocabulary", () => {
     batchIncrementWeights,
     getTopTermListByWeight,
     removeTerm,
+    exportEntries,
+    importEntries,
   };
 });

--- a/src/types/vocabulary.ts
+++ b/src/types/vocabulary.ts
@@ -7,3 +7,28 @@ export interface VocabularyEntry {
   source: VocabularySource;
   createdAt: string;
 }
+
+/** 匯出檔案中的單一詞條（不含 id / createdAt，匯入時重新產生） */
+export interface VocabularyExportEntry {
+  term: string;
+  weight: number;
+  source: VocabularySource;
+}
+
+/** SayIt 字典單檔匯出格式 */
+export interface VocabularyExportFile {
+  format: "sayit-dictionary";
+  version: number;
+  exportedAt: string;
+  terms: VocabularyExportEntry[];
+}
+
+/** 解析匯入來源後、準備寫入 DB 的正規化詞條 */
+export type ImportedTerm = VocabularyExportEntry;
+
+/** 匯入結果統計 */
+export interface ImportResult {
+  added: number;
+  merged: number;
+  skipped: number;
+}

--- a/src/views/DictionaryView.vue
+++ b/src/views/DictionaryView.vue
@@ -4,7 +4,12 @@ import { useVocabularyStore } from "../stores/useVocabularyStore";
 import { extractErrorMessage } from "../lib/errorUtils";
 import { useFeedbackMessage } from "../composables/useFeedbackMessage";
 import { useI18n } from "vue-i18n";
-import { Plus, Trash2, Bot, Hand, Info } from "lucide-vue-next";
+import { Plus, Trash2, Bot, Hand, Info, Download, Upload } from "lucide-vue-next";
+import {
+  serializeExport,
+  parseImportContent,
+  MAX_IMPORT_FILE_BYTES,
+} from "../lib/vocabularyTransfer";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -26,6 +31,10 @@ const newTermInput = ref("");
 const isAdding = ref(false);
 const removingTermIdSet = ref(new Set<string>());
 const feedback = useFeedbackMessage();
+
+const isExporting = ref(false);
+const isImporting = ref(false);
+const importFileInput = ref<HTMLInputElement | null>(null);
 
 const isAddDisabled = computed(
   () => !newTermInput.value.trim() || isAdding.value,
@@ -73,6 +82,92 @@ async function handleRemoveTerm(id: string, term: string) {
   }
 }
 
+function downloadTextFile(filename: string, content: string, mime: string) {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+async function handleExport() {
+  if (isExporting.value) return;
+  try {
+    isExporting.value = true;
+    const entries = await vocabularyStore.exportEntries();
+    if (entries.length === 0) {
+      feedback.show("error", t("dictionary.exportEmpty"));
+      return;
+    }
+    const iso = new Date().toISOString();
+    const stamp = iso.slice(0, 10).replace(/-/g, "");
+    downloadTextFile(
+      `sayit-dictionary-${stamp}.json`,
+      serializeExport(entries, iso),
+      "application/json",
+    );
+    feedback.show(
+      "success",
+      t("dictionary.exportSuccess", { count: entries.length }),
+    );
+  } catch (err) {
+    feedback.show("error", extractErrorMessage(err));
+    captureError(err, { source: "dictionary-export" });
+  } finally {
+    isExporting.value = false;
+  }
+}
+
+function triggerImport() {
+  importFileInput.value?.click();
+}
+
+async function handleImportFileSelected(event: Event) {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  // 清空 input，讓使用者能重複選同一個檔
+  input.value = "";
+  if (!file || isImporting.value) return;
+
+  if (file.size > MAX_IMPORT_FILE_BYTES) {
+    feedback.show("error", t("dictionary.importTooLarge"));
+    return;
+  }
+
+  try {
+    isImporting.value = true;
+    const content = await file.text();
+    const entries = parseImportContent(file.name, content);
+    if (entries.length === 0) {
+      feedback.show("error", t("dictionary.importEmpty"));
+      return;
+    }
+    const result = await vocabularyStore.importEntries(entries);
+    feedback.show(
+      "success",
+      t("dictionary.importSuccess", {
+        added: result.added,
+        merged: result.merged,
+        skipped: result.skipped,
+      }),
+    );
+  } catch (err) {
+    const message = extractErrorMessage(err);
+    const key =
+      message === "INVALID_JSON" || message === "INVALID_FORMAT"
+        ? "dictionary.importInvalidFile"
+        : "dictionary.importFailed";
+    feedback.show("error", t(key, { error: message }));
+    captureError(err, { source: "dictionary-import" });
+  } finally {
+    isImporting.value = false;
+  }
+}
+
 function formatDate(dateString: string): string {
   try {
     // SQLite created_at 儲存為 UTC 且不帶時區後綴，附加 "Z" 確保以 UTC 解析
@@ -105,7 +200,32 @@ onBeforeUnmount(() => {
   <div class="p-6">
     <!-- Page header -->
     <div class="flex flex-wrap items-center justify-between gap-4">
-      <Badge variant="secondary">{{ $t("dictionary.termCount", { count: vocabularyStore.termCount }) }}</Badge>
+      <div class="flex items-center gap-2">
+        <Badge variant="secondary">{{ $t("dictionary.termCount", { count: vocabularyStore.termCount }) }}</Badge>
+        <Button
+          variant="outline"
+          size="sm"
+          :disabled="isExporting"
+          @click="handleExport"
+        >
+          <Download class="h-4 w-4 mr-1" />{{ $t("dictionary.export") }}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          :disabled="isImporting"
+          @click="triggerImport"
+        >
+          <Upload class="h-4 w-4 mr-1" />{{ $t("dictionary.import") }}
+        </Button>
+        <input
+          ref="importFileInput"
+          type="file"
+          accept=".json,.txt,.csv,application/json,text/plain,text/csv"
+          class="hidden"
+          @change="handleImportFileSelected"
+        />
+      </div>
 
       <div class="flex items-center gap-2">
         <div class="flex flex-col">
@@ -136,6 +256,7 @@ onBeforeUnmount(() => {
         <div class="space-y-1 text-sm text-muted-foreground">
           <p>{{ $t("dictionary.description") }}</p>
           <p>{{ $t("dictionary.weightDescription", { limit: 50 }) }}</p>
+          <p>{{ $t("dictionary.transferHint") }}</p>
         </div>
       </div>
     </div>

--- a/tests/unit/use-vocabulary-store.test.ts
+++ b/tests/unit/use-vocabulary-store.test.ts
@@ -232,4 +232,138 @@ describe("useVocabularyStore", () => {
       expect(sql).toContain("'manual'");
     });
   });
+
+  // ==========================================================================
+  // exportEntries
+  // ==========================================================================
+
+  describe("exportEntries", () => {
+    it("應回傳不含 id/createdAt 的詞條", async () => {
+      mockDbSelect.mockResolvedValueOnce([
+        createRawVocabularyRow({ term: "Groq", weight: 30, source: "manual" }),
+        createRawVocabularyRow({ term: "Tauri", weight: 12, source: "ai" }),
+      ]);
+
+      const { useVocabularyStore } = await import(
+        "../../src/stores/useVocabularyStore"
+      );
+      const store = useVocabularyStore();
+
+      const result = await store.exportEntries();
+      expect(result).toEqual([
+        { term: "Groq", weight: 30, source: "manual" },
+        { term: "Tauri", weight: 12, source: "ai" },
+      ]);
+    });
+  });
+
+  // ==========================================================================
+  // importEntries
+  // ==========================================================================
+
+  describe("importEntries", () => {
+    it("空陣列不執行任何 DB 操作", async () => {
+      const { useVocabularyStore } = await import(
+        "../../src/stores/useVocabularyStore"
+      );
+      const store = useVocabularyStore();
+
+      const result = await store.importEntries([]);
+      expect(result).toEqual({ added: 0, merged: 0, skipped: 0 });
+      expect(mockDbExecute).not.toHaveBeenCalled();
+    });
+
+    it("不存在的詞 → 以 weight/source 新增（包在交易內）", async () => {
+      // 第一個 select = 現有詞條（空），後續 fetchTermList 用預設 []
+      mockDbSelect.mockResolvedValueOnce([]);
+
+      const { useVocabularyStore } = await import(
+        "../../src/stores/useVocabularyStore"
+      );
+      const store = useVocabularyStore();
+
+      const result = await store.importEntries([
+        { term: "A", weight: 5, source: "manual" },
+        { term: "B", weight: 1, source: "ai" },
+      ]);
+
+      expect(result).toEqual({ added: 2, merged: 0, skipped: 0 });
+
+      const sqlCalls = mockDbExecute.mock.calls.map((c) => c[0] as string);
+      expect(sqlCalls[0]).toBe("BEGIN TRANSACTION");
+      expect(sqlCalls[sqlCalls.length - 1]).toBe("COMMIT");
+      const insertCalls = mockDbExecute.mock.calls.filter((c) =>
+        (c[0] as string).includes("INSERT INTO vocabulary"),
+      );
+      expect(insertCalls).toHaveLength(2);
+      // INSERT 帶入 weight 與 source
+      expect(insertCalls[0][1]).toEqual([
+        expect.any(String),
+        "A",
+        5,
+        "manual",
+      ]);
+    });
+
+    it("已存在：weight 較大時更新（merged），否則略過（skipped）", async () => {
+      mockDbSelect.mockResolvedValueOnce([
+        { id: "x", term: "A", weight: 2 },
+        { id: "y", term: "B", weight: 10 },
+      ]);
+
+      const { useVocabularyStore } = await import(
+        "../../src/stores/useVocabularyStore"
+      );
+      const store = useVocabularyStore();
+
+      const result = await store.importEntries([
+        { term: "A", weight: 5, source: "manual" }, // 5 > 2 → merged
+        { term: "B", weight: 3, source: "manual" }, // 3 < 10 → skipped
+      ]);
+
+      expect(result).toEqual({ added: 0, merged: 1, skipped: 1 });
+      const updateCalls = mockDbExecute.mock.calls.filter((c) =>
+        (c[0] as string).includes("UPDATE vocabulary SET weight"),
+      );
+      expect(updateCalls).toHaveLength(1);
+      expect(updateCalls[0][1]).toEqual([5, "x"]);
+    });
+
+    it("term 比對大小寫不敏感", async () => {
+      mockDbSelect.mockResolvedValueOnce([
+        { id: "x", term: "Tauri", weight: 1 },
+      ]);
+
+      const { useVocabularyStore } = await import(
+        "../../src/stores/useVocabularyStore"
+      );
+      const store = useVocabularyStore();
+
+      const result = await store.importEntries([
+        { term: "tauri", weight: 9, source: "manual" },
+      ]);
+
+      expect(result).toEqual({ added: 0, merged: 1, skipped: 0 });
+    });
+
+    it("DB 失敗時 ROLLBACK 並拋錯", async () => {
+      mockDbSelect.mockResolvedValueOnce([]);
+      // BEGIN 成功，INSERT 失敗
+      mockDbExecute
+        .mockResolvedValueOnce(undefined) // BEGIN
+        .mockRejectedValueOnce(new Error("disk full")); // INSERT
+
+      const { useVocabularyStore } = await import(
+        "../../src/stores/useVocabularyStore"
+      );
+      const store = useVocabularyStore();
+
+      await expect(
+        store.importEntries([{ term: "A", weight: 1, source: "manual" }]),
+      ).rejects.toThrow();
+
+      const sqlCalls = mockDbExecute.mock.calls.map((c) => c[0] as string);
+      expect(sqlCalls).toContain("ROLLBACK");
+    });
+  });
 });

--- a/tests/unit/vocabulary-transfer.test.ts
+++ b/tests/unit/vocabulary-transfer.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  EXPORT_FORMAT,
+  EXPORT_VERSION,
+  MAX_TERM_LENGTH,
+  buildExportFile,
+  parseImportContent,
+  serializeExport,
+} from "../../src/lib/vocabularyTransfer";
+import type { VocabularyExportEntry } from "../../src/types/vocabulary";
+
+const sampleEntries: VocabularyExportEntry[] = [
+  { term: "Groq", weight: 30, source: "manual" },
+  { term: "Tauri", weight: 12, source: "ai" },
+];
+
+describe("buildExportFile / serializeExport", () => {
+  it("應產生帶 format/version/exportedAt 的物件", () => {
+    const file = buildExportFile(sampleEntries, "2026-06-09T00:00:00.000Z");
+    expect(file.format).toBe(EXPORT_FORMAT);
+    expect(file.version).toBe(EXPORT_VERSION);
+    expect(file.exportedAt).toBe("2026-06-09T00:00:00.000Z");
+    expect(file.terms).toHaveLength(2);
+  });
+
+  it("匯出時正規化非法 weight/source", () => {
+    const file = buildExportFile(
+      [{ term: "X", weight: -5, source: "bogus" as never }],
+      "2026-06-09T00:00:00.000Z",
+    );
+    expect(file.terms[0].weight).toBe(1);
+    expect(file.terms[0].source).toBe("manual");
+  });
+
+  it("serializeExport 產生可被 parseImportContent 解析的 JSON", () => {
+    const json = serializeExport(sampleEntries, "2026-06-09T00:00:00.000Z");
+    const parsed = parseImportContent("backup.json", json);
+    expect(parsed).toEqual(sampleEntries);
+  });
+});
+
+describe("parseImportContent — SayIt JSON", () => {
+  it("依副檔名 .json 解析並保留 weight/source", () => {
+    const json = JSON.stringify({
+      format: "sayit-dictionary",
+      version: 1,
+      terms: [
+        { term: "Vue.js", weight: 8, source: "ai" },
+        { term: "Pinia", weight: 3, source: "manual" },
+      ],
+    });
+    const result = parseImportContent("dict.json", json);
+    expect(result).toEqual([
+      { term: "Vue.js", weight: 8, source: "ai" },
+      { term: "Pinia", weight: 3, source: "manual" },
+    ]);
+  });
+
+  it("無副檔名但內容像 JSON 也能解析", () => {
+    const json = '{ "terms": [{ "term": "Rust" }] }';
+    const result = parseImportContent("noext", json);
+    expect(result).toEqual([{ term: "Rust", weight: 1, source: "manual" }]);
+  });
+
+  it("忽略空白詞條", () => {
+    const json = JSON.stringify({ terms: [{ term: "  " }, { term: "OK" }] });
+    const result = parseImportContent("a.json", json);
+    expect(result).toEqual([{ term: "OK", weight: 1, source: "manual" }]);
+  });
+
+  it("非 JSON 內容的 .json 檔拋出 INVALID_JSON", () => {
+    expect(() => parseImportContent("broken.json", "not json {")).toThrow(
+      "INVALID_JSON",
+    );
+  });
+
+  it("缺少 terms 陣列拋出 INVALID_FORMAT", () => {
+    expect(() => parseImportContent("a.json", '{"foo":1}')).toThrow(
+      "INVALID_FORMAT",
+    );
+  });
+});
+
+describe("parseImportContent — 純文字 / CSV（Typeless 遷移）", () => {
+  it("一行一個詞，全部以 manual/weight=1 匯入", () => {
+    const txt = "蘋果\n香蕉\n芭樂";
+    const result = parseImportContent("typeless.txt", txt);
+    expect(result).toEqual([
+      { term: "蘋果", weight: 1, source: "manual" },
+      { term: "香蕉", weight: 1, source: "manual" },
+      { term: "芭樂", weight: 1, source: "manual" },
+    ]);
+  });
+
+  it("CSV 取第一欄（忽略對應字的第二欄）", () => {
+    const csv = "sequel,SQL\nreact,React";
+    const result = parseImportContent("d.csv", csv);
+    expect(result.map((e) => e.term)).toEqual(["sequel", "react"]);
+  });
+
+  it("跳過空行與多餘空白", () => {
+    const txt = "  Tauri  \n\n\n  Vue  \n";
+    const result = parseImportContent("d.txt", txt);
+    expect(result.map((e) => e.term)).toEqual(["Tauri", "Vue"]);
+  });
+
+  it("以小寫去重，保留先出現者", () => {
+    const txt = "Tauri\ntauri\nVue";
+    const result = parseImportContent("d.txt", txt);
+    expect(result.map((e) => e.term)).toEqual(["Tauri", "Vue"]);
+  });
+
+  it("超長詞條截斷至上限", () => {
+    const long = "a".repeat(MAX_TERM_LENGTH + 50);
+    const result = parseImportContent("d.txt", long);
+    expect(result[0].term).toHaveLength(MAX_TERM_LENGTH);
+  });
+});


### PR DESCRIPTION
Closes #40

## 這個 PR 做了什麼

讓使用者可以把自訂詞彙字典**匯出成單一檔案**，在另一台裝置**匯入**；並提供一條從 Typeless 等沒有匯出功能的工具遷移的通道。不含雲端同步（依 issue 範圍）。

## 功能

- **匯出** —— 字典頁新增「匯出」按鈕，將所有詞條輸出成帶版本的 `sayit-dictionary-YYYYMMDD.json`（含 `term / weight / source`）。
- **匯入 SayIt 備份檔** —— 以 `term`（大小寫不敏感）合併：
  - 不存在 → 新增（added）
  - 已存在且匯入 weight 較大 → 更新為較大值（merged）
  - 已存在且 weight 未較大 → 略過（skipped）
  - 整批包在單一交易內，失敗則 ROLLBACK；完成後回報「新增 / 合併 / 略過」數量。
- **從 Typeless 等工具遷移** —— 匯入同時接受純文字 `.txt` / `.csv`（一行一個詞，逗號時取第一欄）。Typeless 沒有官方匯出、資料又在沙盒中，幫黑盒寫專用 adapter 不划算也容易壞，因此採用「使用者自行整理成文字檔再匯入」這條通用、不會壞的路徑。

## 實作重點

- 採 **webview 原生 Blob 下載 + `<input type=file>`**，**不新增任何 Tauri plugin**，不動 `capabilities` / Rust，PR 面積小、易 review。
- 解析／序列化邏輯抽成純函式 `src/lib/vocabularyTransfer.ts`（含長度上限、weight/source 正規化、大小寫去重）。
- store 新增 `exportEntries()` / `importEntries()`；匯入後 emit `VOCABULARY_CHANGED` 讓其他視窗同步。
- i18n 五語系（en / zh-TW / zh-CN / ja / ko）皆已補齊。

## 測試

- 新增 29 個單元測試（純函式解析／序列化 + store 合併邏輯）。
- 全套件通過：`vue-tsc --noEmit` 無誤、eslint 乾淨、`vitest`（排除 e2e）**390 passed**。

## 注意 / 可討論

- 匯出採 webview 下載 anchor；在 WKWebView / WebView2 會觸發儲存。如果維護者偏好原生存檔對話框，可後續改用 `tauri-plugin-dialog` + `fs`（會需要新增相依與 capability 權限）。
- 匯入檔大小上限暫定 2MB。

🤖 Generated with [Claude Code](https://claude.com/claude-code)