### PR TITLE
chore(clippy): resolve Windows-only lint errors (split from #46)

### DIFF
--- a/src-tauri/src/plugins/audio_control.rs
+++ b/src-tauri/src/plugins/audio_control.rs
@@ -173,7 +173,6 @@ mod macos {
 
 #[cfg(target_os = "windows")]
 mod windows_audio {
-    use windows::core::Interface;
     use windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolume;
     use windows::Win32::Media::Audio::{
         eConsole, eRender, IMMDeviceEnumerator, MMDeviceEnumerator,

--- a/src-tauri/src/plugins/hotkey_listener.rs
+++ b/src-tauri/src/plugins/hotkey_listener.rs
@@ -910,6 +910,7 @@ pub fn reinitialize_hotkey_listener<R: Runtime>(app: AppHandle<R>) -> Result<(),
 
     #[cfg(not(target_os = "macos"))]
     {
+        let _ = &app;
         Ok(())
     }
 }
@@ -934,16 +935,12 @@ mod windows_hook {
     const VK_LWIN: u32 = 0x5B;
     const VK_RWIN: u32 = 0x5C;
 
-    // Windows message constants
-    const WM_KEYDOWN: u32 = 0x0100;
-    const WM_KEYUP: u32 = 0x0101;
-    const WM_SYSKEYDOWN: u32 = 0x0104;
-    const WM_SYSKEYUP: u32 = 0x0105;
+    type KeyHandler = Box<dyn Fn(bool, &TriggerMode) + Send + Sync>;
 
     struct HookContext {
         shared: Arc<Mutex<HotkeySharedState>>,
         is_pressed: Arc<AtomicBool>,
-        key_handler: Box<dyn Fn(bool, &TriggerMode) + Send + Sync>,
+        key_handler: KeyHandler,
         escape_handler: Box<dyn Fn() + Send + Sync>,
         recording_captured_handler: Box<dyn Fn(RecordingCapturedPayload) + Send + Sync>,
         recording_rejected_handler: Box<dyn Fn(RecordingRejectedPayload) + Send + Sync>,
@@ -1069,7 +1066,6 @@ mod windows_hook {
             .ok();
 
         std::thread::spawn(move || unsafe {
-            use windows::Win32::Foundation::*;
             use windows::Win32::UI::WindowsAndMessaging::*;
 
             match SetWindowsHookExW(WH_KEYBOARD_LL, Some(hook_proc), None, 0) {

--- a/src-tauri/src/plugins/keyboard_monitor.rs
+++ b/src-tauri/src/plugins/keyboard_monitor.rs
@@ -250,8 +250,6 @@ fn run_persistent_hook(
     const VK_BACK: u32 = 0x08;
     const VK_DELETE: u32 = 0x2E;
     const VK_RETURN: u32 = 0x0D;
-    const WM_KEYDOWN: u32 = 0x0100;
-    const WM_SYSKEYDOWN: u32 = 0x0104;
 
     struct HookState {
         is_monitoring: Arc<AtomicBool>,
@@ -286,15 +284,15 @@ fn run_persistent_hook(
 
                 if w == WM_KEYDOWN || w == WM_SYSKEYDOWN {
                     // Quality monitor logic (unchanged)
-                    if state.is_monitoring.load(Ordering::SeqCst) {
-                        if kbd.vkCode == VK_BACK || kbd.vkCode == VK_DELETE {
-                            state.was_modified.store(true, Ordering::SeqCst);
-                            #[cfg(debug_assertions)]
-                            println!(
-                                "[keyboard-monitor] Quality: detected modify key: vkCode=0x{:02X}",
-                                kbd.vkCode
-                            );
-                        }
+                    if state.is_monitoring.load(Ordering::SeqCst)
+                        && (kbd.vkCode == VK_BACK || kbd.vkCode == VK_DELETE)
+                    {
+                        state.was_modified.store(true, Ordering::SeqCst);
+                        #[cfg(debug_assertions)]
+                        println!(
+                            "[keyboard-monitor] Quality: detected modify key: vkCode=0x{:02X}",
+                            kbd.vkCode
+                        );
                     }
 
                     // Correction monitor logic (independent)
@@ -317,7 +315,6 @@ fn run_persistent_hook(
     }
 
     unsafe {
-        use windows::Win32::Foundation::*;
         use windows::Win32::UI::WindowsAndMessaging::*;
 
         match SetWindowsHookExW(WH_KEYBOARD_LL, Some(hook_proc), None, 0) {


### PR DESCRIPTION
## 摘要 / Summary

Split out from **#46** per maintainer request: the hotkey/keyboard/audio **clippy cleanup** is unrelated to the Azure provider, so it lives here as an independent, standalone PR against `main`.

These warnings only compile under `#[cfg(target_os = "windows")]` and were never surfaced on the macOS dev machine, but they fail the `windows-latest` `cargo clippy --all-targets -- -D warnings` CI gate.

## 變更 / Changes

- Remove unused Windows imports (`core::Interface`, `Foundation` glob).
- Remove dead `WM_*` constants shadowed by the `windows` crate globs.
- Silence unused `app` on non-macOS `reinitialize_hotkey_listener`.
- Factor the complex key-handler type into a `KeyHandler` alias.
- Collapse a nested quality-monitor `if`.

No runtime/behavior change; the **F23 low-level hook logic is untouched**.

Files: `src-tauri/src/plugins/{audio_control,hotkey_listener,keyboard_monitor}.rs`

---

> Part of splitting the stacked chain (#46–#55) into independent PRs, as requested in #47. This is 1 of 4 PRs replacing **#46**.
