### PR TITLE
feat(dashboard): zero-fill usage trend, fix sparse-data axis (independent of #51)

### DIFF
--- a/src/components/DashboardUsageChart.vue
+++ b/src/components/DashboardUsageChart.vue
@@ -26,10 +26,38 @@ const svgDefs = `
   </linearGradient>
 `;
 
-const xAccessor = (d: DailyUsageTrend) => new Date(d.date);
+// date 為本地時間的 YYYY-MM-DD（與 store 補零、SQL 'localtime' 一致）。
+// 必須用本地建構子解析；new Date("YYYY-MM-DD") 會以 UTC 解讀，
+// 在 UTC- 時區會讓刻度標籤/tooltip 顯示前一天。
+function parseLocalDateKey(key: string): Date {
+  const [year, month, day] = key.split("-").map(Number);
+  return new Date(year, month - 1, day);
+}
+
+const xAccessor = (d: DailyUsageTrend) => parseLocalDateKey(d.date);
 const yAccessor = [(d: DailyUsageTrend) => d.count];
 const fillColor = () => "url(#fillCount)";
 const lineColor = () => chartConfig.value.count.color;
+
+// 在「補零後的完整區間」上均勻挑最多 7 個真實日期當刻度，
+// 確保刻度落在實際資料點上，避免資料稀疏時 D3 在窄 domain 內塞出重複日期標籤。
+const xTickValues = computed<number[]>(() => {
+  const data = props.data;
+  if (data.length === 0) return [];
+  const maxTicks = Math.min(data.length, 7);
+  const indices = new Set<number>();
+  if (maxTicks <= 1) {
+    indices.add(0);
+  } else {
+    const step = (data.length - 1) / (maxTicks - 1);
+    for (let i = 0; i < maxTicks; i++) {
+      indices.add(Math.round(i * step));
+    }
+  }
+  return Array.from(indices).map((i) =>
+    parseLocalDateKey(data[i].date).getTime(),
+  );
+});
 
 function formatDateLabel(d: number): string {
   const date = new Date(d);
@@ -68,7 +96,8 @@ function formatDateLabel(d: number): string {
         :tick-line="false"
         :domain-line="false"
         :grid-line="false"
-        :num-ticks="6"
+        :tick-values="xTickValues"
+        :tick-text-hide-overlapping="true"
         :tick-format="formatDateLabel"
       />
       <VisAxis

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -200,7 +200,7 @@
     "dailyQuota": "Daily Free Quota Remaining",
     "dailyQuotaDetail": "Daily Free Quota Details",
     "usageTrend": "Daily Usage Trend",
-    "last30Days": "Last 30 Days",
+    "lastNDays": "Last {days} Days",
     "recentTranscriptions": "Recent Transcriptions",
     "viewAll": "View All",
     "emptyState": "Start using voice input and your stats will appear here",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -200,7 +200,7 @@
     "dailyQuota": "本日の無料残額",
     "dailyQuotaDetail": "本日の無料残額詳細",
     "usageTrend": "日別使用トレンド",
-    "last30Days": "直近 30 日間",
+    "lastNDays": "直近 {days} 日間",
     "recentTranscriptions": "最近の文字起こし",
     "viewAll": "すべて表示",
     "emptyState": "音声入力を始めると、ここに統計データが表示されます",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -200,7 +200,7 @@
     "dailyQuota": "오늘 남은 무료 할당량",
     "dailyQuotaDetail": "오늘 남은 무료 할당량 상세",
     "usageTrend": "일별 사용 추이",
-    "last30Days": "최근 30일",
+    "lastNDays": "최근 {days}일",
     "recentTranscriptions": "최근 전사",
     "viewAll": "전체 보기",
     "emptyState": "음성 입력을 시작하면 통계가 여기에 표시됩니다",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -200,7 +200,7 @@
     "dailyQuota": "今日剩余免费额度",
     "dailyQuotaDetail": "今日剩余免费额度明细",
     "usageTrend": "每日使用趋势",
-    "last30Days": "最近 30 天",
+    "lastNDays": "最近 {days} 天",
     "recentTranscriptions": "最近转录",
     "viewAll": "查看全部",
     "emptyState": "开始使用语音输入，统计数据将在此显示",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -200,7 +200,7 @@
     "dailyQuota": "今日剩餘免費額度",
     "dailyQuotaDetail": "今日剩餘免費額度明細",
     "usageTrend": "每日使用趨勢",
-    "last30Days": "最近 30 天",
+    "lastNDays": "最近 {days} 天",
     "recentTranscriptions": "最近轉錄",
     "viewAll": "查看全部",
     "emptyState": "開始使用語音輸入，統計數據將在此顯示",

--- a/src/lib/usageTrend.ts
+++ b/src/lib/usageTrend.ts
@@ -1,0 +1,53 @@
+import type { DailyUsageTrend } from "../types/transcription";
+
+// 與 DAILY_USAGE_TREND_SQL 的 DATE(..., 'localtime') 對齊：用本地時間組 YYYY-MM-DD，
+// 不可用 toISOString()（UTC 會差一天，造成補零時對不到實際使用日）。
+function toLocalDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * 將「只含有使用記錄日期」的趨勢資料補零成連續區間。
+ *
+ * 回傳一個長度為 `days` 的升冪序列（從 days-1 天前到 endDate 當天），
+ * 缺席的日期以 count=0 / totalChars=0 補上，確保趨勢圖 X 軸固定顯示完整區間，
+ * 避免資料稀疏時出現重複日期標籤與誤導性的斜線內插。
+ *
+ * 完全沒有任何使用記錄時回傳空陣列，讓圖表維持「尚無使用記錄」空狀態。
+ */
+export function buildDailyUsageSeries(
+  rows: DailyUsageTrend[],
+  days: number,
+  endDate: Date = new Date(),
+): DailyUsageTrend[] {
+  if (rows.length === 0 || days <= 0) return [];
+
+  const byDate = new Map<string, DailyUsageTrend>();
+  for (const row of rows) {
+    byDate.set(row.date, row);
+  }
+
+  const base = new Date(
+    endDate.getFullYear(),
+    endDate.getMonth(),
+    endDate.getDate(),
+  );
+
+  const series: DailyUsageTrend[] = [];
+  for (let offset = days - 1; offset >= 0; offset--) {
+    const current = new Date(base);
+    current.setDate(base.getDate() - offset);
+    const key = toLocalDateKey(current);
+    const existing = byDate.get(key);
+    series.push({
+      date: key,
+      count: existing?.count ?? 0,
+      totalChars: existing?.totalChars ?? 0,
+    });
+  }
+
+  return series;
+}

--- a/src/stores/useHistoryStore.ts
+++ b/src/stores/useHistoryStore.ts
@@ -11,6 +11,7 @@ import type { TriggerMode } from "../types";
 import type { TranscriptionCompletedPayload } from "../types/events";
 import { invoke } from "@tauri-apps/api/core";
 import { getDatabase } from "../lib/database";
+import { buildDailyUsageSeries } from "../lib/usageTrend";
 import { extractErrorMessage } from "../lib/errorUtils";
 import { captureError } from "../lib/sentry";
 import {
@@ -19,6 +20,7 @@ import {
 } from "../composables/useTauriEvents";
 
 const PAGE_SIZE = 20;
+const USAGE_TREND_DAYS = 14;
 
 interface RawTranscriptionRow {
   id: string;
@@ -408,18 +410,28 @@ export const useHistoryStore = defineStore("history", () => {
     return result;
   }
 
-  async function fetchDailyUsageTrend(days = 30): Promise<DailyUsageTrend[]> {
+  async function fetchDailyUsageTrend(
+    days = USAGE_TREND_DAYS,
+  ): Promise<DailyUsageTrend[]> {
     const db = getDatabase();
-    const cutoffTimestamp = Date.now() - days * 86_400_000;
+    // SQL 查詢窗口必須與 buildDailyUsageSeries 的補零窗口對齊（同一個本地日曆區間），
+    // 否則落在「滾動 24h cutoff 但日曆區間外」的記錄會被 SQL 撈到卻被補零丟棄。
+    const endDate = new Date();
+    const startDate = new Date(
+      endDate.getFullYear(),
+      endDate.getMonth(),
+      endDate.getDate() - days + 1,
+    );
     const rows = await db.select<DailyUsageTrendRow[]>(DAILY_USAGE_TREND_SQL, [
-      cutoffTimestamp,
+      startDate.getTime(),
       days,
     ]);
-    return rows.map((row) => ({
+    const mapped = rows.map((row) => ({
       date: row.date,
       count: row.count,
       totalChars: row.total_chars,
     }));
+    return buildDailyUsageSeries(mapped, days, endDate);
   }
 
   async function fetchRecentTranscriptionList(
@@ -562,6 +574,7 @@ export const useHistoryStore = defineStore("history", () => {
     dashboardStats,
     recentTranscriptionList,
     dailyUsageTrendList,
+    usageTrendDays: USAGE_TREND_DAYS,
     fetchTranscriptionList,
     searchTranscriptionList,
     resetAndFetch,

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -249,7 +249,7 @@ onBeforeUnmount(() => {
     <Card class="mt-6">
       <CardHeader>
         <CardTitle class="text-base">{{ $t("dashboard.usageTrend") }}</CardTitle>
-        <CardDescription>{{ $t("dashboard.last30Days") }}</CardDescription>
+        <CardDescription>{{ $t("dashboard.lastNDays", { days: historyStore.usageTrendDays }) }}</CardDescription>
       </CardHeader>
       <CardContent>
         <DashboardUsageChart :data="historyStore.dailyUsageTrendList" />

--- a/tests/unit/usage-trend.test.ts
+++ b/tests/unit/usage-trend.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { buildDailyUsageSeries } from "../../src/lib/usageTrend";
+import type { DailyUsageTrend } from "../../src/types/transcription";
+
+function toLocalKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+describe("buildDailyUsageSeries", () => {
+  it("空輸入回傳空陣列（保留圖表空狀態）", () => {
+    expect(buildDailyUsageSeries([], 14)).toEqual([]);
+  });
+
+  it("days <= 0 回傳空陣列", () => {
+    const rows: DailyUsageTrend[] = [
+      { date: "2026-03-05", count: 1, totalChars: 10 },
+    ];
+    expect(buildDailyUsageSeries(rows, 0)).toEqual([]);
+    expect(buildDailyUsageSeries(rows, -3)).toEqual([]);
+  });
+
+  it("補零成長度為 days 的升冪連續區間，末日為 endDate", () => {
+    const endDate = new Date(2026, 2, 5); // 2026-03-05 本地
+    const rows: DailyUsageTrend[] = [
+      { date: "2026-03-05", count: 5, totalChars: 250 },
+    ];
+    const series = buildDailyUsageSeries(rows, 7, endDate);
+
+    expect(series).toHaveLength(7);
+    // 升冪
+    const dates = series.map((d) => d.date);
+    expect(dates).toEqual([
+      "2026-02-27",
+      "2026-02-28",
+      "2026-03-01",
+      "2026-03-02",
+      "2026-03-03",
+      "2026-03-04",
+      "2026-03-05",
+    ]);
+    expect(series[series.length - 1]).toEqual({
+      date: "2026-03-05",
+      count: 5,
+      totalChars: 250,
+    });
+  });
+
+  it("缺席日補 0、命中日正確映射 count/totalChars", () => {
+    const endDate = new Date(2026, 2, 5);
+    const rows: DailyUsageTrend[] = [
+      { date: "2026-03-05", count: 5, totalChars: 250 },
+      { date: "2026-03-01", count: 3, totalChars: 120 },
+    ];
+    const series = buildDailyUsageSeries(rows, 7, endDate);
+    const byDate = new Map(series.map((d) => [d.date, d]));
+
+    expect(byDate.get("2026-03-01")).toEqual({
+      date: "2026-03-01",
+      count: 3,
+      totalChars: 120,
+    });
+    expect(byDate.get("2026-03-05")).toEqual({
+      date: "2026-03-05",
+      count: 5,
+      totalChars: 250,
+    });
+    // 其餘 5 天皆為 0
+    const zeroDays = series.filter(
+      (d) => d.date !== "2026-03-01" && d.date !== "2026-03-05",
+    );
+    expect(zeroDays).toHaveLength(5);
+    for (const day of zeroDays) {
+      expect(day.count).toBe(0);
+      expect(day.totalChars).toBe(0);
+    }
+  });
+
+  it("跨月邊界產生正確的連續日期", () => {
+    const endDate = new Date(2026, 2, 2); // 2026-03-02
+    const series = buildDailyUsageSeries(
+      [{ date: "2026-03-02", count: 1, totalChars: 4 }],
+      5,
+      endDate,
+    );
+    expect(series.map((d) => d.date)).toEqual([
+      "2026-02-26",
+      "2026-02-27",
+      "2026-02-28",
+      "2026-03-01",
+      "2026-03-02",
+    ]);
+  });
+
+  it("忽略落在區間外的資料列", () => {
+    const endDate = new Date(2026, 2, 5);
+    const rows: DailyUsageTrend[] = [
+      { date: "2026-03-05", count: 5, totalChars: 250 },
+      { date: "2026-02-20", count: 9, totalChars: 999 }, // 區間外
+    ];
+    const series = buildDailyUsageSeries(rows, 7, endDate);
+
+    expect(series).toHaveLength(7);
+    expect(series.some((d) => d.date === "2026-02-20")).toBe(false);
+    // 區間外資料不影響總和
+    const total = series.reduce((sum, d) => sum + d.count, 0);
+    expect(total).toBe(5);
+  });
+
+  it("預設 endDate 為今天，末日為今天的本地日期", () => {
+    const series = buildDailyUsageSeries(
+      [{ date: toLocalKey(new Date()), count: 2, totalChars: 8 }],
+      14,
+    );
+    expect(series).toHaveLength(14);
+    expect(series[series.length - 1].date).toBe(toLocalKey(new Date()));
+    expect(series[series.length - 1].count).toBe(2);
+  });
+});

--- a/tests/unit/use-history-store.test.ts
+++ b/tests/unit/use-history-store.test.ts
@@ -615,9 +615,16 @@ describe("useHistoryStore", () => {
         createRawRow({ id: "recent-1" }),
         createRawRow({ id: "recent-2" }),
       ]);
-      // fetchDailyUsageTrend
+      // fetchDailyUsageTrend（補零後固定 14 天，命中日對應今天）
+      const todayKey = (() => {
+        const now = new Date();
+        const y = now.getFullYear();
+        const m = String(now.getMonth() + 1).padStart(2, "0");
+        const d = String(now.getDate()).padStart(2, "0");
+        return `${y}-${m}-${d}`;
+      })();
       mockDbSelect.mockResolvedValueOnce([
-        { date: "2026-03-01", count: 3, total_chars: 100 },
+        { date: todayKey, count: 3, total_chars: 100 },
       ]);
 
       const { useHistoryStore } = await import(
@@ -635,10 +642,12 @@ describe("useHistoryStore", () => {
       );
       expect(store.recentTranscriptionList).toHaveLength(2);
       expect(store.recentTranscriptionList[0].id).toBe("recent-1");
-      expect(store.dailyUsageTrendList).toHaveLength(1);
-      expect(store.dailyUsageTrendList[0].date).toBe("2026-03-01");
-      expect(store.dailyUsageTrendList[0].count).toBe(3);
-      expect(store.dailyUsageTrendList[0].totalChars).toBe(100);
+      expect(store.dailyUsageTrendList).toHaveLength(14);
+      const lastDay =
+        store.dailyUsageTrendList[store.dailyUsageTrendList.length - 1];
+      expect(lastDay.date).toBe(todayKey);
+      expect(lastDay.count).toBe(3);
+      expect(lastDay.totalChars).toBe(100);
     });
 
     it("[P0] dashboardStats 初始值應全為零", async () => {
@@ -987,11 +996,24 @@ describe("useHistoryStore", () => {
   // ==========================================================================
 
   describe("fetchDailyUsageTrend", () => {
-    it("[P0] 應回傳 camelCase 映射後的趨勢陣列", async () => {
+    it("[P0] 應回傳 camelCase 映射並補零成固定區間的趨勢陣列", async () => {
       const { useHistoryStore } = await import(
         "../../src/stores/useHistoryStore"
       );
       const store = useHistoryStore();
+
+      const toLocalKey = (date: Date) => {
+        const y = date.getFullYear();
+        const m = String(date.getMonth() + 1).padStart(2, "0");
+        const d = String(date.getDate()).padStart(2, "0");
+        return `${y}-${m}-${d}`;
+      };
+      const today = new Date();
+      const yesterday = new Date(today);
+      yesterday.setDate(today.getDate() - 1);
+      const todayKey = toLocalKey(today);
+      const yesterdayKey = toLocalKey(yesterday);
+
       // fetchDashboardStats → DASHBOARD_STATS_SQL
       mockDbSelect.mockResolvedValueOnce([
         { total_count: 0, total_characters: 0, total_recording_duration_ms: 0 },
@@ -1000,24 +1022,32 @@ describe("useHistoryStore", () => {
       mockDbSelect.mockResolvedValueOnce([]);
       // fetchRecentTranscriptionList
       mockDbSelect.mockResolvedValueOnce([]);
-      // fetchDailyUsageTrend
+      // fetchDailyUsageTrend（SQL 只回有使用記錄的日期）
       mockDbSelect.mockResolvedValueOnce([
-        { date: "2026-03-01", count: 5, total_chars: 250 },
-        { date: "2026-02-28", count: 3, total_chars: 120 },
+        { date: todayKey, count: 5, total_chars: 250 },
+        { date: yesterdayKey, count: 3, total_chars: 120 },
       ]);
 
       await store.refreshDashboard();
 
-      expect(store.dailyUsageTrendList).toHaveLength(2);
-      expect(store.dailyUsageTrendList[0]).toEqual({
-        date: "2026-03-01",
+      const list = store.dailyUsageTrendList;
+      // 補零後固定 14 天、升冪、今天在最後
+      expect(list).toHaveLength(14);
+      expect(list[list.length - 1]).toEqual({
+        date: todayKey,
         count: 5,
         totalChars: 250,
       });
-      expect(store.dailyUsageTrendList[1]).toEqual({
-        date: "2026-02-28",
+      expect(list[list.length - 2]).toEqual({
+        date: yesterdayKey,
         count: 3,
         totalChars: 120,
+      });
+      // 缺席日補 0
+      expect(list[0]).toEqual({
+        date: list[0].date,
+        count: 0,
+        totalChars: 0,
       });
     });
 
@@ -1047,9 +1077,15 @@ describe("useHistoryStore", () => {
       expect(sql).toContain("GROUP BY date");
       expect(sql).toContain("LIMIT");
       const params = trendCall[1] as number[];
+      // cutoff 必須是「本地午夜」（與補零的日曆窗口對齊），而非滾動 24h
+      const cutoff = new Date(params[0]);
+      expect(cutoff.getHours()).toBe(0);
+      expect(cutoff.getMinutes()).toBe(0);
+      expect(cutoff.getSeconds()).toBe(0);
+      expect(cutoff.getMilliseconds()).toBe(0);
       expect(params[0]).toBeLessThanOrEqual(Date.now());
-      expect(params[0]).toBeGreaterThan(Date.now() - 31 * 86_400_000);
-      expect(params[1]).toBe(30);
+      expect(params[0]).toBeGreaterThan(Date.now() - 15 * 86_400_000);
+      expect(params[1]).toBe(14);
     });
   });
 });


### PR DESCRIPTION
## 摘要 / Summary

Independent, rebased-onto-`main` version of **#51** (part of splitting the stacked chain #46–#55 into standalone PRs, as requested in #47). Makes the Dashboard **daily usage trend** render correctly when data is sparse.

Previously the chart only used dates that had records; with non-contiguous dates D3 squeezed duplicate labels into a narrow domain and interpolated a single diagonal line between points days apart, falsely implying "used every day". This zero-fills the trend into a fixed continuous calendar window (default 14 days) and puts X-axis ticks on real data points.

## 變更 / Changes

- **`src/lib/usageTrend.ts`** (new) — `buildDailyUsageSeries(rows, days, endDate)` builds a fixed-length, ascending, zero-filled series using **local-time** `YYYY-MM-DD` keys (aligned with SQL `DATE(..., 'localtime')`).
- **`useHistoryStore`** — default window 30 → **14 days** (`USAGE_TREND_DAYS`); SQL cutoff switched from rolling 24h to a **local-midnight calendar window** aligned with the zero-fill window; exposes `usageTrendDays`.
- **`DashboardUsageChart.vue`** — parse date keys as local time (avoids UTC off-by-one), compute `tick-values` on real points, hide overlapping labels.
- **i18n** — `dashboard.last30Days` → `dashboard.lastNDays` (with `{days}`) across all 5 locales.
- Tests: `usage-trend` unit tests + updated `use-history-store` trend tests.

Frontend-only; no Rust or SQL schema changes (only the trend query cutoff calculation).

> Replaces **#51**. The `30→14` day window and zero-fill approach were both approved on the original #51. Contains only the usage-trend change on top of current `main`.
