### PR TITLE
feat(history): per-record retry (re-transcribe / re-enhance) (independent of #53)

### DIFF
--- a/src-tauri/src/plugins/transcription.rs
+++ b/src-tauri/src/plugins/transcription.rs
@@ -76,6 +76,13 @@ pub struct TranscriptionResult {
     pub raw_text: String,
     pub transcription_duration_ms: f64,
     pub no_speech_probability: f64,
+    // Peak/RMS energy (0.0..=1.0) of the source audio. Populated by
+    // `retranscribe_from_file` (computed from the WAV) so the frontend
+    // hallucination detector can run on history retries; the live
+    // transcription path leaves these at 0.0 (it derives energy from the
+    // recorder's StopRecordingResult instead).
+    pub peak_energy_level: f32,
+    pub rms_energy_level: f32,
 }
 
 // ========== Groq API Response ==========
@@ -324,6 +331,9 @@ async fn send_transcription_request(
                     raw_text,
                     transcription_duration_ms,
                     no_speech_probability,
+                    // Live path doesn't compute energy here; retranscribe_from_file fills these in.
+                    peak_energy_level: 0.0,
+                    rms_energy_level: 0.0,
                 });
             }
             Err(failure) => {
@@ -349,6 +359,57 @@ async fn send_transcription_request(
     }
 
     unreachable!("retry loop always returns within MAX_TRANSCRIPTION_ATTEMPTS")
+}
+
+/// Locate the byte offset of the PCM samples (start of the "data" sub-chunk body)
+/// in a RIFF/WAVE buffer. Returns None if the buffer is not a recognizable WAV.
+fn find_wav_data_offset(wav_data: &[u8]) -> Option<usize> {
+    if wav_data.len() < 12 || &wav_data[0..4] != b"RIFF" || &wav_data[8..12] != b"WAVE" {
+        return None;
+    }
+    let mut pos = 12;
+    while pos + 8 <= wav_data.len() {
+        let chunk_id = &wav_data[pos..pos + 4];
+        let chunk_size = u32::from_le_bytes([
+            wav_data[pos + 4],
+            wav_data[pos + 5],
+            wav_data[pos + 6],
+            wav_data[pos + 7],
+        ]) as usize;
+        let body = pos + 8;
+        if chunk_id == b"data" {
+            return Some(body);
+        }
+        // Sub-chunks are word-aligned (padded to an even byte count).
+        pos = body + chunk_size + (chunk_size & 1);
+    }
+    None
+}
+
+/// Compute peak & RMS energy (0.0..=1.0) from a 16-bit mono PCM WAV byte buffer.
+/// Mirrors the live-recording formula in `audio_recorder.rs` so the hallucination
+/// detector can run on re-transcribed history recordings.
+fn compute_wav_energy(wav_data: &[u8]) -> (f32, f32) {
+    let data_offset = find_wav_data_offset(wav_data).unwrap_or(44);
+    let pcm = match wav_data.get(data_offset..) {
+        Some(slice) => slice,
+        None => return (0.0, 0.0),
+    };
+    let sample_count = pcm.len() / 2;
+    if sample_count == 0 {
+        return (0.0, 0.0);
+    }
+    let mut peak = 0.0_f32;
+    let mut sum_squares = 0.0_f64;
+    for frame in pcm.chunks_exact(2) {
+        let s = i16::from_le_bytes([frame[0], frame[1]]);
+        let abs_normalized = (s as f32).abs() / i16::MAX as f32;
+        peak = peak.max(abs_normalized);
+        let norm_f64 = s as f64 / i16::MAX as f64;
+        sum_squares += norm_f64 * norm_f64;
+    }
+    let rms = (sum_squares / sample_count as f64).sqrt() as f32;
+    (peak, rms)
 }
 
 // ========== Commands ==========
@@ -411,7 +472,11 @@ pub async fn retranscribe_from_file(
         wav_data.len()
     );
 
-    send_transcription_request(
+    // Compute energy from the WAV before the bytes are moved into the request,
+    // so the frontend hallucination detector can run on this history retry.
+    let (peak_energy_level, rms_energy_level) = compute_wav_energy(&wav_data);
+
+    let mut result = send_transcription_request(
         wav_data,
         &transcription_state,
         api_key,
@@ -419,7 +484,10 @@ pub async fn retranscribe_from_file(
         model_id,
         language,
     )
-    .await
+    .await?;
+    result.peak_energy_level = peak_energy_level;
+    result.rms_energy_level = rms_energy_level;
+    Ok(result)
 }
 
 #[command]
@@ -487,11 +555,61 @@ mod tests {
             raw_text: "hello".to_string(),
             transcription_duration_ms: 320.5,
             no_speech_probability: 0.01,
+            peak_energy_level: 0.5,
+            rms_energy_level: 0.1,
         };
         let json = serde_json::to_string(&result).unwrap();
         assert!(json.contains("\"rawText\""));
         assert!(json.contains("\"transcriptionDurationMs\""));
         assert!(json.contains("\"noSpeechProbability\""));
+        assert!(json.contains("\"peakEnergyLevel\""));
+        assert!(json.contains("\"rmsEnergyLevel\""));
+    }
+
+    /// Build a minimal mono 16-bit PCM WAV around the given samples.
+    fn make_test_wav(samples: &[i16]) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(b"RIFF");
+        v.extend_from_slice(&0u32.to_le_bytes()); // chunk size (ignored by parser)
+        v.extend_from_slice(b"WAVE");
+        v.extend_from_slice(b"fmt ");
+        v.extend_from_slice(&16u32.to_le_bytes());
+        v.extend_from_slice(&1u16.to_le_bytes()); // PCM
+        v.extend_from_slice(&1u16.to_le_bytes()); // mono
+        v.extend_from_slice(&16000u32.to_le_bytes()); // sample rate
+        v.extend_from_slice(&32000u32.to_le_bytes()); // byte rate
+        v.extend_from_slice(&2u16.to_le_bytes()); // block align
+        v.extend_from_slice(&16u16.to_le_bytes()); // bits per sample
+        v.extend_from_slice(b"data");
+        v.extend_from_slice(&((samples.len() * 2) as u32).to_le_bytes());
+        for &s in samples {
+            v.extend_from_slice(&s.to_le_bytes());
+        }
+        v
+    }
+
+    #[test]
+    fn test_compute_wav_energy() {
+        // Silence → (0, 0)
+        let (peak, rms) = compute_wav_energy(&make_test_wav(&[0i16; 8]));
+        assert!(peak < 1e-6, "peak={peak}");
+        assert!(rms < 1e-6, "rms={rms}");
+
+        // Full-scale square wave → peak ≈ 1.0, rms ≈ 1.0
+        let (peak, rms) =
+            compute_wav_energy(&make_test_wav(&[i16::MAX, -i16::MAX, i16::MAX, -i16::MAX]));
+        assert!((peak - 1.0).abs() < 1e-3, "peak={peak}");
+        assert!(rms > 0.9, "rms={rms}");
+
+        // Empty data chunk → (0, 0), no panic
+        let (peak, rms) = compute_wav_energy(&make_test_wav(&[]));
+        assert_eq!(peak, 0.0);
+        assert_eq!(rms, 0.0);
+
+        // Non-WAV / too short → (0, 0), no panic
+        let (peak, rms) = compute_wav_energy(&[1u8, 2, 3]);
+        assert_eq!(peak, 0.0);
+        assert_eq!(rms, 0.0);
     }
 
     // ========== Retry classification (gh-10) ==========

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -250,7 +250,8 @@
     "retranscribing": "Re-transcribing…",
     "reEnhancing": "Re-enhancing…",
     "retranscribeFailed": "Re-transcription failed, please try again",
-    "reEnhanceFailed": "Re-enhancement failed, please try again"
+    "reEnhanceFailed": "Re-enhancement failed, please try again",
+    "reEnhanceDrift": "Re-enhancement drifted too far from the original; kept the existing result"
   },
   "dictionary": {
     "termCount": "{count} terms",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -244,7 +244,13 @@
     "loadingMore": "Loading more...",
     "playRecording": "Play recording",
     "noRecordingFile": "Recording file not available",
-    "failedBadge": "Failed"
+    "failedBadge": "Failed",
+    "retranscribe": "Re-transcribe",
+    "reEnhance": "Re-enhance",
+    "retranscribing": "Re-transcribing…",
+    "reEnhancing": "Re-enhancing…",
+    "retranscribeFailed": "Re-transcription failed, please try again",
+    "reEnhanceFailed": "Re-enhancement failed, please try again"
   },
   "dictionary": {
     "termCount": "{count} terms",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -250,7 +250,8 @@
     "retranscribing": "再認識中…",
     "reEnhancing": "再整形中…",
     "retranscribeFailed": "再認識に失敗しました。後でもう一度お試しください",
-    "reEnhanceFailed": "再整形に失敗しました。後でもう一度お試しください"
+    "reEnhanceFailed": "再整形に失敗しました。後でもう一度お試しください",
+    "reEnhanceDrift": "整形結果が元のテキストから乖離したため、既存の結果を保持しました"
   },
   "dictionary": {
     "termCount": "{count} 語",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -244,7 +244,13 @@
     "loadingMore": "さらに読み込み中...",
     "playRecording": "録音を再生",
     "noRecordingFile": "録音ファイルがありません",
-    "failedBadge": "認識失敗"
+    "failedBadge": "認識失敗",
+    "retranscribe": "再認識",
+    "reEnhance": "再整形",
+    "retranscribing": "再認識中…",
+    "reEnhancing": "再整形中…",
+    "retranscribeFailed": "再認識に失敗しました。後でもう一度お試しください",
+    "reEnhanceFailed": "再整形に失敗しました。後でもう一度お試しください"
   },
   "dictionary": {
     "termCount": "{count} 語",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -244,7 +244,13 @@
     "loadingMore": "더 불러오는 중...",
     "playRecording": "녹음 재생",
     "noRecordingFile": "녹음 파일이 없습니다",
-    "failedBadge": "인식 실패"
+    "failedBadge": "인식 실패",
+    "retranscribe": "다시 인식",
+    "reEnhance": "다시 정리",
+    "retranscribing": "다시 인식 중…",
+    "reEnhancing": "다시 정리 중…",
+    "retranscribeFailed": "다시 인식하지 못했습니다. 잠시 후 다시 시도하세요",
+    "reEnhanceFailed": "다시 정리하지 못했습니다. 잠시 후 다시 시도하세요"
   },
   "dictionary": {
     "termCount": "{count} 단어",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -250,7 +250,8 @@
     "retranscribing": "다시 인식 중…",
     "reEnhancing": "다시 정리 중…",
     "retranscribeFailed": "다시 인식하지 못했습니다. 잠시 후 다시 시도하세요",
-    "reEnhanceFailed": "다시 정리하지 못했습니다. 잠시 후 다시 시도하세요"
+    "reEnhanceFailed": "다시 정리하지 못했습니다. 잠시 후 다시 시도하세요",
+    "reEnhanceDrift": "정리 결과가 원문에서 너무 벗어나 기존 결과를 유지했습니다"
   },
   "dictionary": {
     "termCount": "{count} 단어",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -244,7 +244,13 @@
     "loadingMore": "加载更多...",
     "playRecording": "播放录音",
     "noRecordingFile": "录音文件不存在",
-    "failedBadge": "识别失败"
+    "failedBadge": "识别失败",
+    "retranscribe": "重新识别",
+    "reEnhance": "重新整理",
+    "retranscribing": "重新识别中…",
+    "reEnhancing": "重新整理中…",
+    "retranscribeFailed": "重新识别失败，请稍后再试",
+    "reEnhanceFailed": "重新整理失败，请稍后再试"
   },
   "dictionary": {
     "termCount": "{count} 词汇",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -250,7 +250,8 @@
     "retranscribing": "重新识别中…",
     "reEnhancing": "重新整理中…",
     "retranscribeFailed": "重新识别失败，请稍后再试",
-    "reEnhanceFailed": "重新整理失败，请稍后再试"
+    "reEnhanceFailed": "重新整理失败，请稍后再试",
+    "reEnhanceDrift": "整理结果与原文差异过大，已保留原结果"
   },
   "dictionary": {
     "termCount": "{count} 词汇",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -244,7 +244,13 @@
     "loadingMore": "載入更多...",
     "playRecording": "播放錄音",
     "noRecordingFile": "錄音檔案不存在",
-    "failedBadge": "辨識失敗"
+    "failedBadge": "辨識失敗",
+    "retranscribe": "重新辨識",
+    "reEnhance": "重新整理",
+    "retranscribing": "重新辨識中…",
+    "reEnhancing": "重新整理中…",
+    "retranscribeFailed": "重新辨識失敗，請稍後再試",
+    "reEnhanceFailed": "重新整理失敗，請稍後再試"
   },
   "dictionary": {
     "termCount": "{count} 詞彙",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -250,7 +250,8 @@
     "retranscribing": "重新辨識中…",
     "reEnhancing": "重新整理中…",
     "retranscribeFailed": "重新辨識失敗，請稍後再試",
-    "reEnhanceFailed": "重新整理失敗，請稍後再試"
+    "reEnhanceFailed": "重新整理失敗，請稍後再試",
+    "reEnhanceDrift": "整理結果與原文差異過大，已保留原結果"
   },
   "dictionary": {
     "termCount": "{count} 詞彙",

--- a/src/lib/enhancer.ts
+++ b/src/lib/enhancer.ts
@@ -12,7 +12,10 @@ import {
 import { getMinimalPromptForLocale } from "../i18n/prompts";
 import type { SupportedLocale } from "../i18n/languageConfig";
 import i18n from "../i18n";
-import { detectEnhancementAnomaly } from "./hallucinationDetector";
+import {
+  detectEnhancementAnomaly,
+  detectSemanticDrift,
+} from "./hallucinationDetector";
 
 const MAX_VOCABULARY_TERMS = 50;
 const DEFAULT_ENHANCEMENT_RETRY_COUNT = 3;
@@ -175,11 +178,16 @@ export interface EnhanceWithGuardResult {
   usage: ChatUsageData | null;
   /** true 表示重試後仍偵測到長度爆炸異常，text 已 fallback 回 rawText。 */
   wasAnomalous: boolean;
+  /** true 表示整理結果與原文 bigram 重疊過低（疑似答非所問）；呼叫端應拒絕並保留既有結果、勿寫入 DB。 */
+  wasDrift: boolean;
+  /** enhanced→raw 的 bigram containment 比例（0~1），供守衛決策與遙測透明化使用。 */
+  driftOverlapRatio: number;
 }
 
 /**
- * enhanceText 外加「增強後長度爆炸」防護：偵測到異常時最多重試 maxRetries 次，
- * 仍異常則 fallback 回 rawText 並標記 wasAnomalous=true。
+ * enhanceText 外加兩道獨立守衛：
+ * 1.「增強後長度爆炸」：偵測到異常時最多重試 maxRetries 次，仍異常則 fallback 回 rawText、標記 wasAnomalous=true。
+ * 2.「語意飄移」（#43）：最終結果與原文 bigram 重疊過低時標記 wasDrift=true，呼叫端據此「拒絕並保留既有結果」。
  * 目前由歷史紀錄重新整理使用；邏輯與 useVoiceFlowStore 即時流程的 inline 迴圈一致，未來可收斂共用。
  */
 export async function enhanceWithAnomalyGuard(
@@ -206,12 +214,33 @@ export async function enhanceWithAnomalyGuard(
   });
 
   if (finalAnomaly.isAnomaly) {
-    return { text: rawText, usage: enhanceResult.usage, wasAnomalous: true };
+    return {
+      text: rawText,
+      usage: enhanceResult.usage,
+      wasAnomalous: true,
+      wasDrift: false,
+      driftOverlapRatio: 1,
+    };
+  }
+
+  // #43 語意飄移守衛：整理結果與原文 bigram 重疊過低 → 疑似答非所問，
+  // 標記 wasDrift 交由呼叫端「拒絕並保留既有結果」（不覆寫 DB）。
+  const drift = detectSemanticDrift(rawText, enhanceResult.text);
+  if (drift.isDrift) {
+    return {
+      text: enhanceResult.text,
+      usage: enhanceResult.usage,
+      wasAnomalous: false,
+      wasDrift: true,
+      driftOverlapRatio: drift.overlapRatio,
+    };
   }
 
   return {
     text: enhanceResult.text,
     usage: enhanceResult.usage,
     wasAnomalous: false,
+    wasDrift: false,
+    driftOverlapRatio: drift.overlapRatio,
   };
 }

--- a/src/lib/enhancer.ts
+++ b/src/lib/enhancer.ts
@@ -12,8 +12,10 @@ import {
 import { getMinimalPromptForLocale } from "../i18n/prompts";
 import type { SupportedLocale } from "../i18n/languageConfig";
 import i18n from "../i18n";
+import { detectEnhancementAnomaly } from "./hallucinationDetector";
 
 const MAX_VOCABULARY_TERMS = 50;
+const DEFAULT_ENHANCEMENT_RETRY_COUNT = 3;
 
 export class EnhancerApiError extends Error {
   constructor(
@@ -166,4 +168,50 @@ export async function enhanceText(
 
   const enhancedContent = stripReasoningTags(result.text);
   return { text: enhancedContent || rawText, usage };
+}
+
+export interface EnhanceWithGuardResult {
+  text: string;
+  usage: ChatUsageData | null;
+  /** true 表示重試後仍偵測到長度爆炸異常，text 已 fallback 回 rawText。 */
+  wasAnomalous: boolean;
+}
+
+/**
+ * enhanceText 外加「增強後長度爆炸」防護：偵測到異常時最多重試 maxRetries 次，
+ * 仍異常則 fallback 回 rawText 並標記 wasAnomalous=true。
+ * 目前由歷史紀錄重新整理使用；邏輯與 useVoiceFlowStore 即時流程的 inline 迴圈一致，未來可收斂共用。
+ */
+export async function enhanceWithAnomalyGuard(
+  rawText: string,
+  apiKey: string,
+  options?: EnhanceOptions,
+  maxRetries = DEFAULT_ENHANCEMENT_RETRY_COUNT,
+): Promise<EnhanceWithGuardResult> {
+  let enhanceResult = await enhanceText(rawText, apiKey, options);
+
+  let retryCount = 0;
+  while (
+    retryCount < maxRetries &&
+    detectEnhancementAnomaly({ rawText, enhancedText: enhanceResult.text })
+      .isAnomaly
+  ) {
+    retryCount++;
+    enhanceResult = await enhanceText(rawText, apiKey, options);
+  }
+
+  const finalAnomaly = detectEnhancementAnomaly({
+    rawText,
+    enhancedText: enhanceResult.text,
+  });
+
+  if (finalAnomaly.isAnomaly) {
+    return { text: rawText, usage: enhanceResult.usage, wasAnomalous: true };
+  }
+
+  return {
+    text: enhanceResult.text,
+    usage: enhanceResult.usage,
+    wasAnomalous: false,
+  };
 }

--- a/src/lib/transcriptTextTransforms.ts
+++ b/src/lib/transcriptTextTransforms.ts
@@ -1,0 +1,21 @@
+import { convertSimplifiedToTraditional } from "./simplifiedToTraditional";
+
+/**
+ * 轉錄原文落地前的文字轉換（共用）。
+ *
+ * 目前只做：有效轉譯語言為繁中（zh-TW）時，把 Whisper 的簡體輸出轉成繁體（#39）。
+ * 有效語言（auto 已解析為介面語言）由呼叫端（store）決定後傳入，
+ * 以維持 `lib/` 不依賴 `stores/` 的分層規則。
+ *
+ * 即時轉錄（useVoiceFlowStore）與歷史「重新辨識」（useHistoryStore）共用此函式，
+ * 確保兩條路徑寫入 raw_text 前都套用一致的轉換。
+ */
+export function applyTranscriptTextTransforms(
+  rawText: string,
+  effectiveLocale: string,
+): string {
+  if (!rawText) return rawText;
+  return effectiveLocale === "zh-TW"
+    ? convertSimplifiedToTraditional(rawText)
+    : rawText;
+}

--- a/src/stores/useHistoryStore.ts
+++ b/src/stores/useHistoryStore.ts
@@ -24,6 +24,7 @@ import {
   enhanceWithAnomalyGuard,
   type EnhanceWithGuardResult,
 } from "../lib/enhancer";
+import { applyTranscriptTextTransforms } from "../lib/transcriptTextTransforms";
 import { detectHallucination } from "../lib/hallucinationDetector";
 import { useSettingsStore } from "./useSettingsStore";
 import { useVocabularyStore } from "./useVocabularyStore";
@@ -178,6 +179,7 @@ const UPDATE_ON_RETRANSCRIBE_SQL = `
       transcription_duration_ms = $2,
       enhancement_duration_ms = NULL,
       was_enhanced = 0,
+      was_modified = NULL,
       char_count = $3
   WHERE id = $4 AND raw_text = $5
 `;
@@ -705,6 +707,18 @@ export const useHistoryStore = defineStore("history", () => {
       return { ok: false, errorKey: "history.retranscribeFailed" };
     }
 
+    // #39：轉譯語言為繁中時，把 Whisper 的簡體輸出轉成繁體（與即時流程一致，落地前一次到位）。
+    // 與主路徑同樣在 raw_text 寫入 DB 前套用，涵蓋空轉錄/幻覺偵測、charCount 與本地更新。
+    const transcriptionLocale = settingsStore.selectedTranscriptionLocale;
+    const effectiveLocale =
+      transcriptionLocale === "auto"
+        ? settingsStore.selectedLocale
+        : transcriptionLocale;
+    result.rawText = applyTranscriptTextTransforms(
+      result.rawText,
+      effectiveLocale,
+    );
+
     // HTTP 成功即計費（不論轉錄內容）→ 記錄 whisper 用量
     recordWhisperUsage(record.id, record.recordingDurationMs, model);
 
@@ -747,6 +761,7 @@ export const useHistoryStore = defineStore("history", () => {
       rawText: result.rawText,
       processedText: null,
       wasEnhanced: false,
+      wasModified: null,
       transcriptionDurationMs,
       enhancementDurationMs: null,
       charCount,
@@ -762,6 +777,13 @@ export const useHistoryStore = defineStore("history", () => {
     record: TranscriptionRecord,
   ): Promise<HistoryRetryResult> {
     if (!record.rawText.trim()) {
+      return { ok: false, errorKey: "history.reEnhanceFailed" };
+    }
+
+    // 編輯模式記錄：rawText 是語音指令、processedText 是編輯結果；
+    // 「重新整理」會把編輯結果覆寫成清理過的指令文字。UI 已停用該按鈕，
+    // 此處為防繞過 UI 直呼 store 的守衛——在任何 API/DB 動作前就擋下。
+    if (record.isEditMode) {
       return { ok: false, errorKey: "history.reEnhanceFailed" };
     }
 
@@ -804,6 +826,12 @@ export const useHistoryStore = defineStore("history", () => {
 
     if (enhanceResult.wasAnomalous) {
       return { ok: false, errorKey: "history.reEnhanceFailed" };
+    }
+
+    // #43 語意飄移守衛：整理結果與原文 bigram 重疊過低（疑似答非所問）→
+    // 拒絕並保留既有結果、不覆寫 DB，並以 reEnhanceDrift 訊息提示使用者。
+    if (enhanceResult.wasDrift) {
+      return { ok: false, errorKey: "history.reEnhanceDrift" };
     }
 
     const db = getDatabase();

--- a/src/stores/useHistoryStore.ts
+++ b/src/stores/useHistoryStore.ts
@@ -6,8 +6,10 @@ import type {
   DailyQuotaUsage,
   ApiUsageRecord,
   DailyUsageTrend,
+  ChatUsageData,
 } from "../types/transcription";
 import type { TriggerMode } from "../types";
+import type { TranscriptionResult } from "../types/audio";
 import type { TranscriptionCompletedPayload } from "../types/events";
 import { invoke } from "@tauri-apps/api/core";
 import { getDatabase } from "../lib/database";
@@ -15,9 +17,27 @@ import { buildDailyUsageSeries } from "../lib/usageTrend";
 import { extractErrorMessage } from "../lib/errorUtils";
 import { captureError } from "../lib/sentry";
 import {
+  calculateChatCostCeiling,
+  calculateWhisperCostCeiling,
+} from "../lib/apiPricing";
+import {
+  enhanceWithAnomalyGuard,
+  type EnhanceWithGuardResult,
+} from "../lib/enhancer";
+import { detectHallucination } from "../lib/hallucinationDetector";
+import { useSettingsStore } from "./useSettingsStore";
+import { useVocabularyStore } from "./useVocabularyStore";
+import {
   emitToWindow,
   TRANSCRIPTION_COMPLETED,
 } from "../composables/useTauriEvents";
+
+/** 歷史紀錄重試（重新辨識／重新整理）的結果；errorKey 為 i18n key，供 UI 顯示。 */
+export interface HistoryRetryResult {
+  ok: boolean;
+  record?: TranscriptionRecord;
+  errorKey?: string;
+}
 
 const PAGE_SIZE = 20;
 const USAGE_TREND_DAYS = 14;
@@ -148,6 +168,26 @@ const UPDATE_ON_RETRY_SUCCESS_SQL = `
       was_enhanced = $5,
       char_count = $6
   WHERE id = $7
+`;
+
+const UPDATE_ON_RETRANSCRIBE_SQL = `
+  UPDATE transcriptions
+  SET status = 'success',
+      raw_text = $1,
+      processed_text = NULL,
+      transcription_duration_ms = $2,
+      enhancement_duration_ms = NULL,
+      was_enhanced = 0,
+      char_count = $3
+  WHERE id = $4 AND raw_text = $5
+`;
+
+const UPDATE_ON_REENHANCE_SQL = `
+  UPDATE transcriptions
+  SET processed_text = $1,
+      was_enhanced = 1,
+      enhancement_duration_ms = $2
+  WHERE id = $3 AND raw_text = $4
 `;
 
 const DELETE_API_USAGE_BY_TRANSCRIPTION_SQL = `
@@ -565,6 +605,227 @@ export const useHistoryStore = defineStore("history", () => {
     return deletedCount;
   }
 
+  function applyLocalRecordUpdate(
+    id: string,
+    patch: Partial<TranscriptionRecord>,
+  ): TranscriptionRecord | undefined {
+    const target = transcriptionList.value.find((r) => r.id === id);
+    if (!target) return undefined;
+    const updated: TranscriptionRecord = { ...target, ...patch };
+    transcriptionList.value = transcriptionList.value.map((r) =>
+      r.id === id ? updated : r,
+    );
+    return updated;
+  }
+
+  function recordWhisperUsage(
+    transcriptionId: string,
+    audioDurationMs: number,
+    model: string,
+  ): void {
+    void addApiUsage({
+      id: crypto.randomUUID(),
+      transcriptionId,
+      apiType: "whisper",
+      model,
+      promptTokens: null,
+      completionTokens: null,
+      totalTokens: null,
+      promptTimeMs: null,
+      completionTimeMs: null,
+      totalTimeMs: null,
+      audioDurationMs,
+      estimatedCostCeiling: calculateWhisperCostCeiling(audioDurationMs, model),
+    }).catch((err) =>
+      captureError(err, { source: "history", step: "retranscribe-usage" }),
+    );
+  }
+
+  function recordChatUsage(
+    transcriptionId: string,
+    usage: ChatUsageData | null,
+    model: string,
+  ): void {
+    if (!usage) return;
+    void addApiUsage({
+      id: crypto.randomUUID(),
+      transcriptionId,
+      apiType: "chat",
+      model,
+      promptTokens: usage.promptTokens,
+      completionTokens: usage.completionTokens,
+      totalTokens: usage.totalTokens,
+      promptTimeMs: usage.promptTimeMs ?? null,
+      completionTimeMs: usage.completionTimeMs ?? null,
+      totalTimeMs: usage.totalTimeMs ?? null,
+      audioDurationMs: null,
+      estimatedCostCeiling: calculateChatCostCeiling(usage.totalTokens, model),
+    }).catch((err) =>
+      captureError(err, { source: "history", step: "reenhance-usage" }),
+    );
+  }
+
+  /**
+   * 歷史紀錄「重新辨識」：以保存的錄音檔重送轉錄。成功即把該筆 failed → success
+   * 並清空整理結果（等待使用者另行「重新整理」）。只更新該筆，不貼上、不碰 HUD 狀態機。
+   */
+  async function retranscribeRecord(
+    record: TranscriptionRecord,
+  ): Promise<HistoryRetryResult> {
+    if (!record.audioFilePath) {
+      return { ok: false, errorKey: "history.noRecordingFile" };
+    }
+
+    const settingsStore = useSettingsStore();
+    const vocabularyStore = useVocabularyStore();
+
+    if (!settingsStore.getApiKey()) {
+      await settingsStore.refreshApiKey();
+    }
+    const apiKey = settingsStore.getApiKey();
+    if (!apiKey) {
+      return { ok: false, errorKey: "errors.apiKeyMissing" };
+    }
+
+    const whisperTermList = await vocabularyStore.getTopTermListByWeight(50);
+    const model = settingsStore.selectedWhisperModelId;
+
+    let result: TranscriptionResult;
+    try {
+      result = await invoke<TranscriptionResult>("retranscribe_from_file", {
+        filePath: record.audioFilePath,
+        apiKey,
+        vocabularyTermList:
+          whisperTermList.length > 0 ? whisperTermList : null,
+        modelId: model,
+        language: settingsStore.getWhisperLanguageCode(),
+      });
+    } catch (err) {
+      captureError(err, { source: "history", step: "retranscribe-invoke" });
+      return { ok: false, errorKey: "history.retranscribeFailed" };
+    }
+
+    // HTTP 成功即計費（不論轉錄內容）→ 記錄 whisper 用量
+    recordWhisperUsage(record.id, record.recordingDurationMs, model);
+
+    // 空轉錄或幻覺 → 保留 failed、不覆寫原文
+    const isEmpty = !result.rawText || !result.rawText.trim();
+    // 時長未知/非正時跳過語速異常層（無法判斷語速），仍保留能量/NSP 偵測
+    const recordingDurationForDetection =
+      record.recordingDurationMs > 0
+        ? record.recordingDurationMs
+        : Number.MAX_SAFE_INTEGER;
+    const hallucination = detectHallucination({
+      rawText: result.rawText,
+      recordingDurationMs: recordingDurationForDetection,
+      peakEnergyLevel: result.peakEnergyLevel,
+      rmsEnergyLevel: result.rmsEnergyLevel,
+      noSpeechProbability: result.noSpeechProbability,
+    });
+    if (isEmpty || hallucination.isHallucination) {
+      return { ok: false, errorKey: "history.retranscribeFailed" };
+    }
+
+    const charCount = result.rawText.length;
+    const transcriptionDurationMs = Math.round(result.transcriptionDurationMs);
+
+    const db = getDatabase();
+    const res = await db.execute(UPDATE_ON_RETRANSCRIBE_SQL, [
+      result.rawText,
+      transcriptionDurationMs,
+      charCount,
+      record.id,
+      record.rawText,
+    ]);
+    if (!res?.rowsAffected) {
+      // 樂觀鎖：紀錄已被刪除或 raw_text 已被並行修改 → 放棄，不覆寫
+      return { ok: false, errorKey: "history.retranscribeFailed" };
+    }
+
+    const updated = applyLocalRecordUpdate(record.id, {
+      status: "success",
+      rawText: result.rawText,
+      processedText: null,
+      wasEnhanced: false,
+      transcriptionDurationMs,
+      enhancementDurationMs: null,
+      charCount,
+    });
+    return { ok: true, record: updated };
+  }
+
+  /**
+   * 歷史紀錄「重新整理」：用既有原文重跑 AI 校對，套用與即時流程相同的長度爆炸防護。
+   * 成功則寫入 processed_text 並標記 was_enhanced。只更新該筆，不貼上、不碰 HUD 狀態機。
+   */
+  async function reEnhanceRecord(
+    record: TranscriptionRecord,
+  ): Promise<HistoryRetryResult> {
+    if (!record.rawText.trim()) {
+      return { ok: false, errorKey: "history.reEnhanceFailed" };
+    }
+
+    const settingsStore = useSettingsStore();
+    const vocabularyStore = useVocabularyStore();
+
+    await settingsStore.refreshLlmApiKey();
+    const llmApiKey = settingsStore.getLlmApiKey();
+    if (!llmApiKey) {
+      return { ok: false, errorKey: "errors.apiKeyMissing" };
+    }
+
+    const termList = await vocabularyStore.getTopTermListByWeight(50);
+    const startTime = performance.now();
+
+    let enhanceResult: EnhanceWithGuardResult;
+    try {
+      enhanceResult = await enhanceWithAnomalyGuard(
+        record.rawText,
+        llmApiKey,
+        {
+          systemPrompt: settingsStore.getAiPrompt(),
+          vocabularyTermList: termList.length > 0 ? termList : undefined,
+          modelId: settingsStore.selectedLlmModelId,
+        },
+      );
+    } catch (err) {
+      captureError(err, { source: "history", step: "reenhance" });
+      return { ok: false, errorKey: "history.reEnhanceFailed" };
+    }
+
+    const enhancementDurationMs = Math.round(performance.now() - startTime);
+
+    // API 已呼叫（即使 anomaly fallback）→ 記錄 chat 用量
+    recordChatUsage(
+      record.id,
+      enhanceResult.usage,
+      settingsStore.selectedLlmModelId,
+    );
+
+    if (enhanceResult.wasAnomalous) {
+      return { ok: false, errorKey: "history.reEnhanceFailed" };
+    }
+
+    const db = getDatabase();
+    const res = await db.execute(UPDATE_ON_REENHANCE_SQL, [
+      enhanceResult.text,
+      enhancementDurationMs,
+      record.id,
+      record.rawText,
+    ]);
+    if (!res?.rowsAffected) {
+      // 樂觀鎖：紀錄已被刪除或 raw_text 已被並行修改（整理結果基於舊原文）→ 放棄
+      return { ok: false, errorKey: "history.reEnhanceFailed" };
+    }
+
+    const updated = applyLocalRecordUpdate(record.id, {
+      processedText: enhanceResult.text,
+      wasEnhanced: true,
+      enhancementDurationMs,
+    });
+    return { ok: true, record: updated };
+  }
+
   return {
     transcriptionList,
     isLoading,
@@ -589,5 +850,7 @@ export const useHistoryStore = defineStore("history", () => {
     clearAudioFilePathByIdList,
     deleteTranscription,
     deleteAllRecordingFiles,
+    retranscribeRecord,
+    reEnhanceRecord,
   };
 });

--- a/src/stores/useVoiceFlowStore.ts
+++ b/src/stores/useVoiceFlowStore.ts
@@ -16,7 +16,7 @@ import { enhanceText, buildSystemPrompt } from "../lib/enhancer";
 import { getEditModePromptForLocale } from "../i18n/prompts";
 import type { SupportedLocale } from "../i18n/languageConfig";
 import { analyzeCorrections } from "../lib/vocabularyAnalyzer";
-import { convertSimplifiedToTraditional } from "../lib/simplifiedToTraditional";
+import { applyTranscriptTextTransforms as applySharedTranscriptTextTransforms } from "../lib/transcriptTextTransforms";
 import i18n from "../i18n";
 import { useVocabularyStore } from "./useVocabularyStore";
 import { useHistoryStore } from "./useHistoryStore";
@@ -86,8 +86,8 @@ function t(key: string, params?: Record<string, unknown>): string {
 
 /**
  * 轉錄原文落地前的文字轉換。
- * 目前只做：轉譯語言解析為繁中（zh-TW）時，把 Whisper 的簡體輸出轉成繁體（#39）。
- * 「auto」模式回退到介面語言；其餘語言原樣返回。
+ * 解析有效轉譯語言（auto 回退到介面語言）後，委派給共用的 applyTranscriptTextTransforms。
+ * 目前只做：繁中（zh-TW）時把 Whisper 的簡體輸出轉成繁體（#39）。
  */
 function applyTranscriptTextTransforms(rawText: string): string {
   if (!rawText) return rawText;
@@ -97,9 +97,7 @@ function applyTranscriptTextTransforms(rawText: string): string {
     transcriptionLocale === "auto"
       ? settingsStore.selectedLocale
       : transcriptionLocale;
-  return effectiveLocale === "zh-TW"
-    ? convertSimplifiedToTraditional(rawText)
-    : rawText;
+  return applySharedTranscriptTextTransforms(rawText, effectiveLocale);
 }
 
 const MONITOR_POLL_INTERVAL_MS = 250;

--- a/src/types/audio.ts
+++ b/src/types/audio.ts
@@ -20,4 +20,9 @@ export interface TranscriptionResult {
   rawText: string;
   transcriptionDurationMs: number;
   noSpeechProbability: number;
+  /** Peak energy 0.0..=1.0 of the source audio. 0 for the live path (energy comes
+   *  from StopRecordingResult); populated by retranscribe_from_file for history retries. */
+  peakEnergyLevel: number;
+  /** RMS energy 0.0..=1.0 of the source audio. See peakEnergyLevel. */
+  rmsEnergyLevel: number;
 }

--- a/src/views/HistoryView.vue
+++ b/src/views/HistoryView.vue
@@ -349,7 +349,7 @@ onBeforeUnmount(() => {
                     size="icon"
                     class="h-7 w-7"
                     data-testid="reenhance-button"
-                    :disabled="!record.rawText.trim() || retryingId !== null"
+                    :disabled="!record.rawText.trim() || record.isEditMode || retryingId !== null"
                     :title="retryingId === record.id && retryingAction === 'enhance' ? $t('history.reEnhancing') : $t('history.reEnhance')"
                     @click.stop="handleReEnhance(record)"
                   >

--- a/src/views/HistoryView.vue
+++ b/src/views/HistoryView.vue
@@ -19,7 +19,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search, ChevronDown, Copy, Check, Trash2, Play, Pause } from "lucide-vue-next";
+import { Search, ChevronDown, Copy, Check, Trash2, Play, Pause, RefreshCw, Sparkles, Loader2 } from "lucide-vue-next";
 import { captureError } from "../lib/sentry";
 
 const historyStore = useHistoryStore();
@@ -30,6 +30,9 @@ const copiedRecordId = ref<string | null>(null);
 const copiedRawRecordId = ref<string | null>(null);
 const sentinelRef = ref<HTMLElement | null>(null);
 const playingRecordId = ref<string | null>(null);
+const retryingId = ref<string | null>(null);
+const retryingAction = ref<"transcribe" | "enhance" | null>(null);
+const retryError = ref<{ id: string; key: string } | null>(null);
 let currentAudio: HTMLAudioElement | null = null;
 let currentBlobUrl: string | null = null;
 
@@ -145,6 +148,50 @@ async function handlePlayRecording(record: TranscriptionRecord) {
     cleanupAudio();
     playingRecordId.value = null;
     captureError(err, { source: "history-view", step: "play-recording" });
+  }
+}
+
+async function handleRetranscribe(record: TranscriptionRecord) {
+  if (retryingId.value) return;
+  retryingId.value = record.id;
+  retryingAction.value = "transcribe";
+  retryError.value = null;
+  try {
+    const result = await historyStore.retranscribeRecord(record);
+    if (!result.ok) {
+      retryError.value = {
+        id: record.id,
+        key: result.errorKey ?? "history.retranscribeFailed",
+      };
+    }
+  } catch (err) {
+    captureError(err, { source: "history-view", step: "retranscribe" });
+    retryError.value = { id: record.id, key: "history.retranscribeFailed" };
+  } finally {
+    retryingId.value = null;
+    retryingAction.value = null;
+  }
+}
+
+async function handleReEnhance(record: TranscriptionRecord) {
+  if (retryingId.value) return;
+  retryingId.value = record.id;
+  retryingAction.value = "enhance";
+  retryError.value = null;
+  try {
+    const result = await historyStore.reEnhanceRecord(record);
+    if (!result.ok) {
+      retryError.value = {
+        id: record.id,
+        key: result.errorKey ?? "history.reEnhanceFailed",
+      };
+    }
+  } catch (err) {
+    captureError(err, { source: "history-view", step: "reenhance" });
+    retryError.value = { id: record.id, key: "history.reEnhanceFailed" };
+  } finally {
+    retryingId.value = null;
+    retryingAction.value = null;
   }
 }
 
@@ -285,6 +332,30 @@ onBeforeUnmount(() => {
                     <Check v-if="copiedRecordId === record.id" class="h-3.5 w-3.5 text-green-400" />
                     <Copy v-else class="h-3.5 w-3.5" />
                   </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    class="h-7 w-7"
+                    data-testid="retranscribe-button"
+                    :disabled="!record.audioFilePath || retryingId !== null"
+                    :title="retryingId === record.id && retryingAction === 'transcribe' ? $t('history.retranscribing') : (record.audioFilePath ? $t('history.retranscribe') : $t('history.noRecordingFile'))"
+                    @click.stop="handleRetranscribe(record)"
+                  >
+                    <Loader2 v-if="retryingId === record.id && retryingAction === 'transcribe'" class="h-3.5 w-3.5 animate-spin" />
+                    <RefreshCw v-else class="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    class="h-7 w-7"
+                    data-testid="reenhance-button"
+                    :disabled="!record.rawText.trim() || retryingId !== null"
+                    :title="retryingId === record.id && retryingAction === 'enhance' ? $t('history.reEnhancing') : $t('history.reEnhance')"
+                    @click.stop="handleReEnhance(record)"
+                  >
+                    <Loader2 v-if="retryingId === record.id && retryingAction === 'enhance'" class="h-3.5 w-3.5 animate-spin" />
+                    <Sparkles v-else class="h-3.5 w-3.5" />
+                  </Button>
                   <ChevronDown
                     class="h-3.5 w-3.5 text-muted-foreground transition-transform"
                     :class="{ 'rotate-180': expandedRecordId === record.id }"
@@ -295,6 +366,14 @@ onBeforeUnmount(() => {
                 {{ truncateText(getDisplayText(record)) }}
               </p>
             </div>
+            <!-- 重試錯誤訊息（每筆常駐顯示）-->
+            <p
+              v-if="retryError && retryError.id === record.id"
+              class="px-5 pb-2 text-xs text-destructive"
+              data-testid="retry-error"
+            >
+              {{ $t(retryError.key) }}
+            </p>
 
             <!-- 展開詳細 -->
             <div

--- a/tests/component/HistoryView.test.ts
+++ b/tests/component/HistoryView.test.ts
@@ -1,0 +1,183 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import i18n from "../../src/i18n";
+import HistoryView from "../../src/views/HistoryView.vue";
+import type { TranscriptionRecord } from "../../src/types/transcription";
+
+vi.mock("../../src/composables/useTauriEvents", () => ({
+  listenToEvent: vi.fn().mockResolvedValue(vi.fn()),
+  TRANSCRIPTION_COMPLETED: "transcription:completed",
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+vi.mock("../../src/lib/sentry", () => ({ captureError: vi.fn() }));
+
+let historyState: Record<string, unknown>;
+
+vi.mock("../../src/stores/useHistoryStore", () => ({
+  useHistoryStore: () => historyState,
+}));
+
+function createRecord(
+  overrides: Partial<TranscriptionRecord> = {},
+): TranscriptionRecord {
+  return {
+    id: "rec-1",
+    timestamp: 1700000000000,
+    rawText: "原始文字內容",
+    processedText: null,
+    recordingDurationMs: 3000,
+    transcriptionDurationMs: 280,
+    enhancementDurationMs: null,
+    charCount: 6,
+    triggerMode: "hold",
+    wasEnhanced: false,
+    wasModified: null,
+    createdAt: "",
+    audioFilePath: "C:/rec/rec-1.wav",
+    status: "success",
+    isEditMode: false,
+    editSourceText: null,
+    ...overrides,
+  };
+}
+
+function makeHistory(records: TranscriptionRecord[]): Record<string, unknown> {
+  return {
+    transcriptionList: records,
+    isLoading: false,
+    hasMore: false,
+    searchQuery: "",
+    resetAndFetch: vi.fn().mockResolvedValue(undefined),
+    loadMore: vi.fn().mockResolvedValue(undefined),
+    retranscribeRecord: vi.fn().mockResolvedValue({ ok: true }),
+    reEnhanceRecord: vi.fn().mockResolvedValue({ ok: true }),
+  };
+}
+
+const ButtonStub = {
+  name: "Button",
+  inheritAttrs: false,
+  template: '<button v-bind="$attrs"><slot /></button>',
+};
+
+async function mountExpanded(record: TranscriptionRecord) {
+  historyState = makeHistory([record]);
+  const wrapper = mount(HistoryView, {
+    global: {
+      plugins: [i18n],
+      stubs: { Button: ButtonStub },
+    },
+  });
+  // 展開該紀錄，重試按鈕位於展開詳細區
+  await wrapper.find(".cursor-pointer").trigger("click");
+  await wrapper.vm.$nextTick();
+  return wrapper;
+}
+
+describe("HistoryView 重試按鈕", () => {
+  beforeEach(() => {
+    class IOStub {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("IntersectionObserver", IOStub);
+  });
+
+  it("[P1] 每筆紀錄都顯示兩顆重試按鈕（含已整理的成功紀錄）", async () => {
+    const wrapper = await mountExpanded(
+      createRecord({
+        status: "success",
+        wasEnhanced: true,
+        processedText: "整理後文字",
+        rawText: "原文",
+        audioFilePath: "C:/rec/rec-1.wav",
+      }),
+    );
+    expect(wrapper.find('[data-testid="retranscribe-button"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.find('[data-testid="reenhance-button"]').exists()).toBe(true);
+  });
+
+  it("[P1] 有錄音檔與原文 → 兩顆皆可用（未 disabled）", async () => {
+    const wrapper = await mountExpanded(
+      createRecord({ audioFilePath: "C:/rec/rec-1.wav", rawText: "有原文" }),
+    );
+    expect(
+      wrapper.find('[data-testid="retranscribe-button"]').attributes("disabled"),
+    ).toBeUndefined();
+    expect(
+      wrapper.find('[data-testid="reenhance-button"]').attributes("disabled"),
+    ).toBeUndefined();
+  });
+
+  it("[P1] 無錄音檔 → 重新辨識 disabled、重新整理仍可用", async () => {
+    const wrapper = await mountExpanded(
+      createRecord({ audioFilePath: null, rawText: "有原文" }),
+    );
+    expect(
+      wrapper.find('[data-testid="retranscribe-button"]').attributes("disabled"),
+    ).toBeDefined();
+    expect(
+      wrapper.find('[data-testid="reenhance-button"]').attributes("disabled"),
+    ).toBeUndefined();
+  });
+
+  it("[P1] 空原文 → 重新整理 disabled、重新辨識仍可用", async () => {
+    const wrapper = await mountExpanded(
+      createRecord({
+        status: "failed",
+        audioFilePath: "C:/rec/rec-1.wav",
+        rawText: "   ",
+      }),
+    );
+    expect(
+      wrapper.find('[data-testid="reenhance-button"]').attributes("disabled"),
+    ).toBeDefined();
+    expect(
+      wrapper.find('[data-testid="retranscribe-button"]').attributes("disabled"),
+    ).toBeUndefined();
+  });
+
+  it("[P1] 點擊重新辨識會呼叫 store.retranscribeRecord", async () => {
+    const record = createRecord({ audioFilePath: "C:/rec/rec-1.wav" });
+    const wrapper = await mountExpanded(record);
+    await wrapper.find('[data-testid="retranscribe-button"]').trigger("click");
+    expect(historyState.retranscribeRecord).toHaveBeenCalledTimes(1);
+    expect(historyState.retranscribeRecord).toHaveBeenCalledWith(record);
+  });
+
+  it("[P1] 點擊重新整理會呼叫 store.reEnhanceRecord", async () => {
+    const record = createRecord({ rawText: "可整理的原文" });
+    const wrapper = await mountExpanded(record);
+    await wrapper.find('[data-testid="reenhance-button"]').trigger("click");
+    expect(historyState.reEnhanceRecord).toHaveBeenCalledTimes(1);
+    expect(historyState.reEnhanceRecord).toHaveBeenCalledWith(record);
+  });
+
+  it("[P2] 重試進行中，其他紀錄的重試按鈕應 disabled（全域鎖）", async () => {
+    let resolveRetry: (v: { ok: boolean }) => void = () => {};
+    const recordA = createRecord({ id: "rec-A", audioFilePath: "C:/a.wav" });
+    const recordB = createRecord({ id: "rec-B", audioFilePath: "C:/b.wav" });
+    historyState = makeHistory([recordA, recordB]);
+    historyState.retranscribeRecord = vi.fn(
+      () => new Promise<{ ok: boolean }>((r) => (resolveRetry = r)),
+    );
+    const wrapper = mount(HistoryView, {
+      global: { plugins: [i18n], stubs: { Button: ButtonStub } },
+    });
+    // 重試按鈕常駐於摘要列，每筆一顆
+    const buttons = wrapper.findAll('[data-testid="retranscribe-button"]');
+    expect(buttons.length).toBe(2);
+    // 觸發 A 的重試（pending）
+    await buttons[0].trigger("click");
+    await wrapper.vm.$nextTick();
+    // B 的重試按鈕應因全域鎖 disabled
+    const after = wrapper.findAll('[data-testid="retranscribe-button"]');
+    expect(after[1].attributes("disabled")).toBeDefined();
+    resolveRetry({ ok: true });
+  });
+});

--- a/tests/component/HistoryView.test.ts
+++ b/tests/component/HistoryView.test.ts
@@ -142,6 +142,24 @@ describe("HistoryView 重試按鈕", () => {
     ).toBeUndefined();
   });
 
+  it("[P1] 編輯模式紀錄 → 重新整理 disabled（避免覆寫編輯結果）、重新辨識仍可用", async () => {
+    const wrapper = await mountExpanded(
+      createRecord({
+        status: "success",
+        audioFilePath: "C:/rec/rec-1.wav",
+        rawText: "把這句改成正式語氣",
+        processedText: "使用者的編輯結果",
+        isEditMode: true,
+      }),
+    );
+    expect(
+      wrapper.find('[data-testid="reenhance-button"]').attributes("disabled"),
+    ).toBeDefined();
+    expect(
+      wrapper.find('[data-testid="retranscribe-button"]').attributes("disabled"),
+    ).toBeUndefined();
+  });
+
   it("[P1] 點擊重新辨識會呼叫 store.retranscribeRecord", async () => {
     const record = createRecord({ audioFilePath: "C:/rec/rec-1.wav" });
     const wrapper = await mountExpanded(record);

--- a/tests/unit/enhancer.test.ts
+++ b/tests/unit/enhancer.test.ts
@@ -523,3 +523,54 @@ describe("enhancer.ts", () => {
     });
   });
 });
+
+describe("enhanceWithAnomalyGuard", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("[P1] 正常整理（無長度爆炸）→ wasAnomalous=false 並採用整理結果", async () => {
+    mockFetch.mockResolvedValue(
+      createSuccessResponse("這是一段整理後的書面語文字。"),
+    );
+    const { enhanceWithAnomalyGuard } = await import("../../src/lib/enhancer");
+    const result = await enhanceWithAnomalyGuard(
+      "這是一段整理後的書面語文字",
+      TEST_API_KEY,
+    );
+    expect(result.wasAnomalous).toBe(false);
+    expect(result.text).toBe("這是一段整理後的書面語文字。");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("[P1] 持續長度爆炸 → 重試後 fallback 回 rawText 並標記 wasAnomalous", async () => {
+    mockFetch.mockResolvedValue(createSuccessResponse("爆".repeat(50)));
+    const { enhanceWithAnomalyGuard } = await import("../../src/lib/enhancer");
+    const result = await enhanceWithAnomalyGuard("短文", TEST_API_KEY, undefined, 3);
+    expect(result.wasAnomalous).toBe(true);
+    expect(result.text).toBe("短文");
+    // 1 次初始 + 3 次重試
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+  });
+
+  it("[P1] 首次長度爆炸、重試後正常 → 採用正常結果", async () => {
+    mockFetch
+      .mockResolvedValueOnce(createSuccessResponse("爆".repeat(50)))
+      .mockResolvedValueOnce(createSuccessResponse("正常整理後的文字"));
+    const { enhanceWithAnomalyGuard } = await import("../../src/lib/enhancer");
+    const result = await enhanceWithAnomalyGuard(
+      "一段原始口語文字",
+      TEST_API_KEY,
+      undefined,
+      3,
+    );
+    expect(result.wasAnomalous).toBe(false);
+    expect(result.text).toBe("正常整理後的文字");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/enhancer.test.ts
+++ b/tests/unit/enhancer.test.ts
@@ -573,4 +573,30 @@ describe("enhanceWithAnomalyGuard", () => {
     expect(result.text).toBe("正常整理後的文字");
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
+
+  it("[P1] 語意飄移（整理結果與原文幾乎不相干）→ wasDrift=true、不 fallback、保留整理文字供拒絕", async () => {
+    mockFetch.mockResolvedValue(
+      createSuccessResponse("股票市場今日收盤下跌"),
+    );
+    const { enhanceWithAnomalyGuard } = await import("../../src/lib/enhancer");
+    const result = await enhanceWithAnomalyGuard(
+      "今天天氣很好適合出門散步",
+      TEST_API_KEY,
+    );
+    expect(result.wasAnomalous).toBe(false);
+    expect(result.wasDrift).toBe(true);
+    expect(result.driftOverlapRatio).toBeLessThan(0.2);
+  });
+
+  it("[P1] 正常整理（高 bigram 重疊）→ wasDrift=false", async () => {
+    mockFetch.mockResolvedValue(
+      createSuccessResponse("這是一段整理後的書面語文字。"),
+    );
+    const { enhanceWithAnomalyGuard } = await import("../../src/lib/enhancer");
+    const result = await enhanceWithAnomalyGuard(
+      "這是一段整理後的書面語文字",
+      TEST_API_KEY,
+    );
+    expect(result.wasDrift).toBe(false);
+  });
 });

--- a/tests/unit/transcript-text-transforms.test.ts
+++ b/tests/unit/transcript-text-transforms.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockConvert = vi.hoisted(() => vi.fn());
+vi.mock("../../src/lib/simplifiedToTraditional", () => ({
+  convertSimplifiedToTraditional: mockConvert,
+}));
+
+import { applyTranscriptTextTransforms } from "../../src/lib/transcriptTextTransforms";
+
+describe("applyTranscriptTextTransforms", () => {
+  beforeEach(() => {
+    mockConvert.mockReset().mockImplementation((t: string) => `[繁]${t}`);
+  });
+
+  it("[P1] zh-TW → 委派 convertSimplifiedToTraditional", () => {
+    const result = applyTranscriptTextTransforms("简体", "zh-TW");
+    expect(mockConvert).toHaveBeenCalledWith("简体");
+    expect(result).toBe("[繁]简体");
+  });
+
+  it("[P1] 非 zh-TW（en）→ 原樣返回、不呼叫轉換", () => {
+    const result = applyTranscriptTextTransforms("hello", "en");
+    expect(mockConvert).not.toHaveBeenCalled();
+    expect(result).toBe("hello");
+  });
+
+  it("[P1] 非 zh-TW（zh-CN）→ 原樣返回、不轉換", () => {
+    const result = applyTranscriptTextTransforms("简体内容", "zh-CN");
+    expect(mockConvert).not.toHaveBeenCalled();
+    expect(result).toBe("简体内容");
+  });
+
+  it("[P2] 空字串 → 直接返回、不呼叫轉換", () => {
+    const result = applyTranscriptTextTransforms("", "zh-TW");
+    expect(mockConvert).not.toHaveBeenCalled();
+    expect(result).toBe("");
+  });
+});

--- a/tests/unit/use-history-retry.test.ts
+++ b/tests/unit/use-history-retry.test.ts
@@ -1,0 +1,298 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import type { TranscriptionRecord } from "../../src/types/transcription";
+
+const h = vi.hoisted(() => {
+  const mockDbExecute = vi.fn();
+  const mockInvoke = vi.fn();
+  const mockEnhanceGuard = vi.fn();
+  const mockGetTopTerms = vi.fn();
+  const settingsStub = {
+    getApiKey: () => "whisper-key",
+    refreshApiKey: vi.fn(),
+    selectedWhisperModelId: "whisper-large-v3-turbo",
+    getWhisperLanguageCode: () => "zh",
+    refreshLlmApiKey: vi.fn(),
+    getLlmApiKey: () => "llm-key",
+    selectedLlmModelId: "llama-3.3-70b-versatile",
+    getAiPrompt: () => "prompt",
+  };
+  return {
+    mockDbExecute,
+    mockInvoke,
+    mockEnhanceGuard,
+    mockGetTopTerms,
+    settingsStub,
+  };
+});
+
+vi.mock("../../src/lib/database", () => ({
+  getDatabase: () => ({ execute: h.mockDbExecute, select: vi.fn() }),
+}));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: h.mockInvoke }));
+vi.mock("../../src/composables/useTauriEvents", () => ({
+  emitToWindow: vi.fn().mockResolvedValue(undefined),
+  TRANSCRIPTION_COMPLETED: "transcription:completed",
+}));
+vi.mock("../../src/lib/sentry", () => ({ captureError: vi.fn() }));
+vi.mock("../../src/lib/enhancer", () => ({
+  enhanceWithAnomalyGuard: h.mockEnhanceGuard,
+}));
+vi.mock("../../src/stores/useSettingsStore", () => ({
+  useSettingsStore: () => h.settingsStub,
+}));
+vi.mock("../../src/stores/useVocabularyStore", () => ({
+  useVocabularyStore: () => ({ getTopTermListByWeight: h.mockGetTopTerms }),
+}));
+
+import { useHistoryStore } from "../../src/stores/useHistoryStore";
+
+function createRecord(
+  overrides: Partial<TranscriptionRecord> = {},
+): TranscriptionRecord {
+  return {
+    id: "rec-1",
+    timestamp: 1700000000000,
+    rawText: "",
+    processedText: null,
+    recordingDurationMs: 3000,
+    transcriptionDurationMs: 0,
+    enhancementDurationMs: null,
+    charCount: 0,
+    triggerMode: "hold",
+    wasEnhanced: false,
+    wasModified: null,
+    createdAt: "",
+    audioFilePath: "C:/rec/rec-1.wav",
+    status: "failed",
+    isEditMode: false,
+    editSourceText: null,
+    ...overrides,
+  };
+}
+
+const GOOD_TRANSCRIBE_RESULT = {
+  rawText: "這是重新辨識後得到的完整句子內容。",
+  transcriptionDurationMs: 280,
+  noSpeechProbability: 0.01,
+  peakEnergyLevel: 0.5,
+  rmsEnergyLevel: 0.1,
+};
+
+describe("useHistoryStore retry", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    h.mockDbExecute
+      .mockReset()
+      .mockResolvedValue({ rowsAffected: 1, lastInsertId: 0 });
+    h.mockInvoke.mockReset();
+    h.mockEnhanceGuard.mockReset();
+    h.mockGetTopTerms.mockReset().mockResolvedValue([]);
+    h.settingsStub.refreshApiKey.mockReset().mockResolvedValue(undefined);
+    h.settingsStub.refreshLlmApiKey.mockReset().mockResolvedValue(undefined);
+  });
+
+  describe("retranscribeRecord", () => {
+    it("[P1] 成功重新辨識 → flip success、更新原文、清空整理結果", async () => {
+      h.mockInvoke.mockResolvedValue(GOOD_TRANSCRIBE_RESULT);
+      const store = useHistoryStore();
+      const record = createRecord();
+      store.transcriptionList.push(record);
+
+      const res = await store.retranscribeRecord(record);
+
+      expect(res.ok).toBe(true);
+      expect(h.mockInvoke).toHaveBeenCalledWith(
+        "retranscribe_from_file",
+        expect.objectContaining({ filePath: record.audioFilePath }),
+      );
+      expect(store.transcriptionList[0].status).toBe("success");
+      expect(store.transcriptionList[0].rawText).toBe(
+        GOOD_TRANSCRIBE_RESULT.rawText,
+      );
+      expect(store.transcriptionList[0].processedText).toBeNull();
+      expect(store.transcriptionList[0].wasEnhanced).toBe(false);
+    });
+
+    it("[P1] 無錄音檔 → 不呼叫後端並回 noRecordingFile", async () => {
+      const store = useHistoryStore();
+      const record = createRecord({ audioFilePath: null });
+      const res = await store.retranscribeRecord(record);
+      expect(res.ok).toBe(false);
+      expect(res.errorKey).toBe("history.noRecordingFile");
+      expect(h.mockInvoke).not.toHaveBeenCalled();
+    });
+
+    it("[P1] 空轉錄結果 → 保留 failed、不覆寫原文", async () => {
+      h.mockInvoke.mockResolvedValue({ ...GOOD_TRANSCRIBE_RESULT, rawText: "  " });
+      const store = useHistoryStore();
+      const record = createRecord({ rawText: "原本失敗" });
+      store.transcriptionList.push(record);
+      const res = await store.retranscribeRecord(record);
+      expect(res.ok).toBe(false);
+      expect(res.errorKey).toBe("history.retranscribeFailed");
+      expect(store.transcriptionList[0].status).toBe("failed");
+      expect(store.transcriptionList[0].rawText).toBe("原本失敗");
+    });
+
+    it("[P2] 幻覺結果（靜音 + 高 NSP）→ 保留 failed", async () => {
+      h.mockInvoke.mockResolvedValue({
+        rawText: "幻覺出來的一長串文字但其實完全沒有人聲",
+        transcriptionDurationMs: 280,
+        noSpeechProbability: 0.95,
+        peakEnergyLevel: 0,
+        rmsEnergyLevel: 0,
+      });
+      const store = useHistoryStore();
+      const record = createRecord();
+      store.transcriptionList.push(record);
+      const res = await store.retranscribeRecord(record);
+      expect(res.ok).toBe(false);
+      expect(store.transcriptionList[0].status).toBe("failed");
+    });
+
+    it("[P2] 樂觀鎖 rowsAffected=0 → 回失敗、紀錄不變", async () => {
+      h.mockInvoke.mockResolvedValue(GOOD_TRANSCRIBE_RESULT);
+      h.mockDbExecute.mockResolvedValue({ rowsAffected: 0, lastInsertId: 0 });
+      const store = useHistoryStore();
+      const record = createRecord();
+      store.transcriptionList.push(record);
+      const res = await store.retranscribeRecord(record);
+      expect(res.ok).toBe(false);
+      expect(store.transcriptionList[0].status).toBe("failed");
+    });
+
+    it("[P2] recordingDurationMs<=0 仍可成功（跳過語速異常層、保留能量/NSP）", async () => {
+      h.mockInvoke.mockResolvedValue(GOOD_TRANSCRIBE_RESULT);
+      const store = useHistoryStore();
+      const record = createRecord({ recordingDurationMs: 0 });
+      store.transcriptionList.push(record);
+      const res = await store.retranscribeRecord(record);
+      expect(res.ok).toBe(true);
+      expect(store.transcriptionList[0].status).toBe("success");
+    });
+
+    it("[P2] 已整理的成功紀錄重新辨識 → 清空整理、status 仍 success", async () => {
+      h.mockInvoke.mockResolvedValue(GOOD_TRANSCRIBE_RESULT);
+      const store = useHistoryStore();
+      const record = createRecord({
+        status: "success",
+        wasEnhanced: true,
+        processedText: "舊的整理結果",
+        rawText: "舊原文",
+      });
+      store.transcriptionList.push(record);
+      const res = await store.retranscribeRecord(record);
+      expect(res.ok).toBe(true);
+      expect(store.transcriptionList[0].status).toBe("success");
+      expect(store.transcriptionList[0].rawText).toBe(
+        GOOD_TRANSCRIBE_RESULT.rawText,
+      );
+      expect(store.transcriptionList[0].processedText).toBeNull();
+      expect(store.transcriptionList[0].wasEnhanced).toBe(false);
+      // 樂觀鎖：UPDATE 以 snapshot raw_text（"舊原文"）作為條件
+      const updateCall = h.mockDbExecute.mock.calls.find((c) =>
+        String(c[0]).includes("UPDATE transcriptions"),
+      );
+      expect(updateCall?.[1]).toContain("舊原文");
+    });
+  });
+
+  describe("reEnhanceRecord", () => {
+    it("[P1] 成功整理 → 寫入 processed_text、標記 was_enhanced", async () => {
+      h.mockEnhanceGuard.mockResolvedValue({
+        text: "整理後的書面語句子。",
+        usage: null,
+        wasAnomalous: false,
+      });
+      const store = useHistoryStore();
+      const record = createRecord({
+        status: "success",
+        rawText: "原始口語內容",
+        wasEnhanced: false,
+      });
+      store.transcriptionList.push(record);
+      const res = await store.reEnhanceRecord(record);
+      expect(res.ok).toBe(true);
+      expect(store.transcriptionList[0].processedText).toBe(
+        "整理後的書面語句子。",
+      );
+      expect(store.transcriptionList[0].wasEnhanced).toBe(true);
+    });
+
+    it("[P1] 空原文 → 不呼叫 LLM 並回失敗", async () => {
+      const store = useHistoryStore();
+      const record = createRecord({ status: "success", rawText: "   " });
+      const res = await store.reEnhanceRecord(record);
+      expect(res.ok).toBe(false);
+      expect(res.errorKey).toBe("history.reEnhanceFailed");
+      expect(h.mockEnhanceGuard).not.toHaveBeenCalled();
+    });
+
+    it("[P1] 長度爆炸 anomaly → 不 finalize、保留未整理", async () => {
+      h.mockEnhanceGuard.mockResolvedValue({
+        text: "原始口語內容",
+        usage: null,
+        wasAnomalous: true,
+      });
+      const store = useHistoryStore();
+      const record = createRecord({
+        status: "success",
+        rawText: "原始口語內容",
+        wasEnhanced: false,
+      });
+      store.transcriptionList.push(record);
+      const res = await store.reEnhanceRecord(record);
+      expect(res.ok).toBe(false);
+      expect(res.errorKey).toBe("history.reEnhanceFailed");
+      expect(store.transcriptionList[0].wasEnhanced).toBe(false);
+      expect(store.transcriptionList[0].processedText).toBeNull();
+    });
+
+    it("[P2] 已整理紀錄可再次重新整理（覆寫整理結果）", async () => {
+      h.mockEnhanceGuard.mockResolvedValue({
+        text: "新的整理結果。",
+        usage: null,
+        wasAnomalous: false,
+      });
+      const store = useHistoryStore();
+      const record = createRecord({
+        status: "success",
+        wasEnhanced: true,
+        processedText: "舊整理",
+        rawText: "原始口語內容",
+      });
+      store.transcriptionList.push(record);
+      const res = await store.reEnhanceRecord(record);
+      expect(res.ok).toBe(true);
+      expect(store.transcriptionList[0].processedText).toBe("新的整理結果。");
+      expect(store.transcriptionList[0].wasEnhanced).toBe(true);
+    });
+
+    it("[P2] 樂觀鎖 rowsAffected=0（raw_text 並行變動）→ 回失敗、不覆寫整理", async () => {
+      h.mockEnhanceGuard.mockResolvedValue({
+        text: "基於舊原文的整理。",
+        usage: null,
+        wasAnomalous: false,
+      });
+      h.mockDbExecute.mockResolvedValue({ rowsAffected: 0, lastInsertId: 0 });
+      const store = useHistoryStore();
+      const record = createRecord({
+        status: "success",
+        rawText: "原始口語內容",
+        wasEnhanced: false,
+      });
+      store.transcriptionList.push(record);
+      const res = await store.reEnhanceRecord(record);
+      expect(res.ok).toBe(false);
+      expect(res.errorKey).toBe("history.reEnhanceFailed");
+      expect(store.transcriptionList[0].wasEnhanced).toBe(false);
+      expect(store.transcriptionList[0].processedText).toBeNull();
+      // 樂觀鎖：UPDATE 以 snapshot raw_text 作為條件
+      const updateCall = h.mockDbExecute.mock.calls.find((c) =>
+        String(c[0]).includes("UPDATE transcriptions"),
+      );
+      expect(updateCall?.[1]).toContain(record.rawText);
+    });
+  });
+});

--- a/tests/unit/use-history-retry.test.ts
+++ b/tests/unit/use-history-retry.test.ts
@@ -7,11 +7,14 @@ const h = vi.hoisted(() => {
   const mockInvoke = vi.fn();
   const mockEnhanceGuard = vi.fn();
   const mockGetTopTerms = vi.fn();
+  const mockTransform = vi.fn();
   const settingsStub = {
     getApiKey: () => "whisper-key",
     refreshApiKey: vi.fn(),
     selectedWhisperModelId: "whisper-large-v3-turbo",
     getWhisperLanguageCode: () => "zh",
+    selectedTranscriptionLocale: "en",
+    selectedLocale: "en",
     refreshLlmApiKey: vi.fn(),
     getLlmApiKey: () => "llm-key",
     selectedLlmModelId: "llama-3.3-70b-versatile",
@@ -22,6 +25,7 @@ const h = vi.hoisted(() => {
     mockInvoke,
     mockEnhanceGuard,
     mockGetTopTerms,
+    mockTransform,
     settingsStub,
   };
 });
@@ -37,6 +41,9 @@ vi.mock("../../src/composables/useTauriEvents", () => ({
 vi.mock("../../src/lib/sentry", () => ({ captureError: vi.fn() }));
 vi.mock("../../src/lib/enhancer", () => ({
   enhanceWithAnomalyGuard: h.mockEnhanceGuard,
+}));
+vi.mock("../../src/lib/transcriptTextTransforms", () => ({
+  applyTranscriptTextTransforms: h.mockTransform,
 }));
 vi.mock("../../src/stores/useSettingsStore", () => ({
   useSettingsStore: () => h.settingsStub,
@@ -88,6 +95,9 @@ describe("useHistoryStore retry", () => {
     h.mockInvoke.mockReset();
     h.mockEnhanceGuard.mockReset();
     h.mockGetTopTerms.mockReset().mockResolvedValue([]);
+    h.mockTransform.mockReset().mockImplementation((text: string) => text);
+    h.settingsStub.selectedTranscriptionLocale = "en";
+    h.settingsStub.selectedLocale = "en";
     h.settingsStub.refreshApiKey.mockReset().mockResolvedValue(undefined);
     h.settingsStub.refreshLlmApiKey.mockReset().mockResolvedValue(undefined);
   });
@@ -196,6 +206,63 @@ describe("useHistoryStore retry", () => {
       );
       expect(updateCall?.[1]).toContain("舊原文");
     });
+
+    it("[P1] zh-TW → 落地前套用簡繁轉換（共用 transform），存入轉換後文字", async () => {
+      h.mockInvoke.mockResolvedValue({
+        ...GOOD_TRANSCRIBE_RESULT,
+        rawText: "简体转录结果",
+      });
+      h.settingsStub.selectedTranscriptionLocale = "zh-TW";
+      h.mockTransform.mockImplementation((text: string) =>
+        text === "简体转录结果" ? "簡體轉錄結果" : text,
+      );
+      const store = useHistoryStore();
+      const record = createRecord();
+      store.transcriptionList.push(record);
+
+      const res = await store.retranscribeRecord(record);
+
+      expect(res.ok).toBe(true);
+      expect(h.mockTransform).toHaveBeenCalledWith("简体转录结果", "zh-TW");
+      expect(store.transcriptionList[0].rawText).toBe("簡體轉錄結果");
+      // 證明寫入 DB 的 raw_text（SQL $1）也是轉換後文字，而非本地才轉
+      const updateCall = h.mockDbExecute.mock.calls.find((c) =>
+        String(c[0]).includes("UPDATE transcriptions"),
+      );
+      expect(updateCall?.[1]?.[0]).toBe("簡體轉錄結果");
+    });
+
+    it("[P1] auto 模式 → transform 以介面語言解析的 effectiveLocale 呼叫", async () => {
+      h.mockInvoke.mockResolvedValue(GOOD_TRANSCRIBE_RESULT);
+      h.settingsStub.selectedTranscriptionLocale = "auto";
+      h.settingsStub.selectedLocale = "zh-TW";
+      const store = useHistoryStore();
+      const record = createRecord();
+      store.transcriptionList.push(record);
+
+      await store.retranscribeRecord(record);
+
+      expect(h.mockTransform).toHaveBeenCalledWith(
+        GOOD_TRANSCRIBE_RESULT.rawText,
+        "zh-TW",
+      );
+    });
+
+    it("[P2] 重新辨識 → 重置 was_modified（SQL + 本地皆歸零）", async () => {
+      h.mockInvoke.mockResolvedValue(GOOD_TRANSCRIBE_RESULT);
+      const store = useHistoryStore();
+      const record = createRecord({ wasModified: true });
+      store.transcriptionList.push(record);
+
+      const res = await store.retranscribeRecord(record);
+
+      expect(res.ok).toBe(true);
+      expect(store.transcriptionList[0].wasModified).toBeNull();
+      const updateCall = h.mockDbExecute.mock.calls.find((c) =>
+        String(c[0]).includes("UPDATE transcriptions"),
+      );
+      expect(String(updateCall?.[0])).toContain("was_modified = NULL");
+    });
   });
 
   describe("reEnhanceRecord", () => {
@@ -293,6 +360,55 @@ describe("useHistoryStore retry", () => {
         String(c[0]).includes("UPDATE transcriptions"),
       );
       expect(updateCall?.[1]).toContain(record.rawText);
+    });
+
+    it("[P1] 編輯模式紀錄 → 直接拒絕、不呼叫 LLM、不動 DB（防繞過守衛）", async () => {
+      const store = useHistoryStore();
+      const record = createRecord({
+        status: "success",
+        rawText: "把這句改成正式語氣",
+        processedText: "使用者的編輯結果",
+        isEditMode: true,
+      });
+      store.transcriptionList.push(record);
+
+      const res = await store.reEnhanceRecord(record);
+
+      expect(res.ok).toBe(false);
+      expect(h.mockEnhanceGuard).not.toHaveBeenCalled();
+      expect(h.mockDbExecute).not.toHaveBeenCalled();
+      expect(h.settingsStub.refreshLlmApiKey).not.toHaveBeenCalled();
+      expect(h.mockGetTopTerms).not.toHaveBeenCalled();
+      expect(store.transcriptionList[0].processedText).toBe("使用者的編輯結果");
+    });
+
+    it("[P1] 語意飄移（wasDrift）→ 拒絕並保留既有結果、不寫 DB、回 reEnhanceDrift", async () => {
+      h.mockEnhanceGuard.mockResolvedValue({
+        text: "與原文完全不相干的回答內容。",
+        usage: null,
+        wasAnomalous: false,
+        wasDrift: true,
+        driftOverlapRatio: 0.05,
+      });
+      const store = useHistoryStore();
+      const record = createRecord({
+        status: "success",
+        rawText: "原始口語內容",
+        wasEnhanced: true,
+        processedText: "既有的整理結果",
+      });
+      store.transcriptionList.push(record);
+
+      const res = await store.reEnhanceRecord(record);
+
+      expect(res.ok).toBe(false);
+      expect(res.errorKey).toBe("history.reEnhanceDrift");
+      // 拒絕並保留：不執行 UPDATE，既有 processedText 原封不動
+      const updateCall = h.mockDbExecute.mock.calls.find((c) =>
+        String(c[0]).includes("UPDATE transcriptions"),
+      );
+      expect(updateCall).toBeUndefined();
+      expect(store.transcriptionList[0].processedText).toBe("既有的整理結果");
     });
   });
 });


### PR DESCRIPTION
## 摘要 / Summary

Independent, rebased-onto-`main` version of **#53** (part of splitting the stacked chain #46–#55 into standalone PRs, as requested in #47). Adds **per-record Retry** to every history entry.

`Closes #42`

Two always-present icon actions on each history summary row (next to play/copy):

- **🔁 Re-transcribe** — re-runs Whisper from the saved recording file (disabled when no recording file exists).
- **✨ Re-enhance** — re-runs AI cleanup from the existing raw text (disabled when there is no raw text).

Both **update the record in place** (no cursor paste, no HUD involvement), record Whisper/chat API usage, use value-based optimistic locking (`WHERE id = ? AND raw_text = ?`), and share `enhanceWithAnomalyGuard` (length-explosion retry + fallback) plus the WAV energy hallucination check. Users can recover from punctuation/formatting errors or empty output **without re-speaking** (behavior modeled on Typeless).

## Implementation

- **`retranscribe_from_file`** now parses the source WAV to compute peak/RMS energy (returns `peak_energy_level` / `rms_energy_level`) so the frontend hallucination check runs fully on history retry too.
- **`useHistoryStore`** — `retranscribeRecord` / `reEnhanceRecord`; **HistoryView** summary-row buttons; shared `enhanceWithAnomalyGuard`; i18n (5 locales); unit + component tests.

### No new IPC
Reuses the existing `retranscribe_from_file` command and `enhanceText` (plugin-http). History updates happen in-place in the Dashboard window; no cross-window emit.

### Provider handling (rebased to `main`)
The retry path uses the existing provider API on `main` — `getApiKey`/`selectedWhisperModelId` for Whisper and `getLlmApiKey`/`selectedLlmModelId` for the LLM (provider derived from the model). It does **not** depend on the Azure/Foundry provider PR; it works with the current Groq/OpenAI/Anthropic providers.

> Replaces **#53**. Adapted off the old Azure-coupled settings API to `main`'s provider API so it's independently reviewable/mergeable.
