### PR TITLE
feat(dashboard): today's usage for billed LLM providers (split 2/4 of #46)

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -212,7 +212,12 @@
     "quotaLlmRequests": "LLM {used}/{limit} req",
     "quotaLlmTokens": "LLM {used}/{limit} tokens",
     "vocabularyAnalysis": "Dictionary Analysis",
-    "vocabularyAnalysisUsage": "Dictionary Analysis: {requests} req / {tokens} tokens"
+    "vocabularyAnalysisUsage": "Dictionary Analysis: {requests} req / {tokens} tokens",
+    "dailyUsage": "Today's Usage",
+    "billedPlan": "Billed",
+    "billedNoFreeQuota": "Pay-as-you-go — no free quota limit",
+    "usageWhisper": "Whisper: {requests} req · {audio}",
+    "usageLlm": "LLM: {requests} req · {tokens} tokens"
   },
   "history": {
     "searchPlaceholder": "Search transcriptions...",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -212,7 +212,12 @@
     "quotaLlmRequests": "LLM {used}/{limit} 回",
     "quotaLlmTokens": "LLM {used}/{limit} tokens",
     "vocabularyAnalysis": "辞書分析",
-    "vocabularyAnalysisUsage": "辞書分析：{requests} 回 / {tokens} tokens"
+    "vocabularyAnalysisUsage": "辞書分析：{requests} 回 / {tokens} tokens",
+    "dailyUsage": "本日の使用量",
+    "billedPlan": "従量課金",
+    "billedNoFreeQuota": "従量課金 — 無料枠なし",
+    "usageWhisper": "Whisper：{requests} 回 · {audio}",
+    "usageLlm": "LLM：{requests} 回 · {tokens} tokens"
   },
   "history": {
     "searchPlaceholder": "文字起こし履歴を検索...",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -212,7 +212,12 @@
     "quotaLlmRequests": "LLM {used}/{limit} 회",
     "quotaLlmTokens": "LLM {used}/{limit} tokens",
     "vocabularyAnalysis": "사전 분석",
-    "vocabularyAnalysisUsage": "사전 분석: {requests} 회 / {tokens} tokens"
+    "vocabularyAnalysisUsage": "사전 분석: {requests} 회 / {tokens} tokens",
+    "dailyUsage": "오늘 사용량",
+    "billedPlan": "유료",
+    "billedNoFreeQuota": "유료 요금제 — 무료 할당량 없음",
+    "usageWhisper": "Whisper: {requests}회 · {audio}",
+    "usageLlm": "LLM: {requests}회 · {tokens} tokens"
   },
   "history": {
     "searchPlaceholder": "전사 기록 검색...",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -212,7 +212,12 @@
     "quotaLlmRequests": "LLM {used}/{limit} 次",
     "quotaLlmTokens": "LLM {used}/{limit} tokens",
     "vocabularyAnalysis": "字典分析",
-    "vocabularyAnalysisUsage": "字典分析：{requests} 次 / {tokens} tokens"
+    "vocabularyAnalysisUsage": "字典分析：{requests} 次 / {tokens} tokens",
+    "dailyUsage": "今日用量",
+    "billedPlan": "计费",
+    "billedNoFreeQuota": "付费方案 — 无免费额度限制",
+    "usageWhisper": "Whisper：{requests} 次 · {audio}",
+    "usageLlm": "LLM：{requests} 次 · {tokens} tokens"
   },
   "history": {
     "searchPlaceholder": "搜索转录记录...",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -212,7 +212,12 @@
     "quotaLlmRequests": "LLM {used}/{limit} 次",
     "quotaLlmTokens": "LLM {used}/{limit} tokens",
     "vocabularyAnalysis": "字典分析",
-    "vocabularyAnalysisUsage": "字典分析：{requests} 次 / {tokens} tokens"
+    "vocabularyAnalysisUsage": "字典分析：{requests} 次 / {tokens} tokens",
+    "dailyUsage": "今日用量",
+    "billedPlan": "計費",
+    "billedNoFreeQuota": "付費方案 — 無免費額度限制",
+    "usageWhisper": "Whisper：{requests} 次 · {audio}",
+    "usageLlm": "LLM：{requests} 次 · {tokens} tokens"
   },
   "history": {
     "searchPlaceholder": "搜尋轉錄記錄...",

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -43,55 +43,99 @@ const historyStore = useHistoryStore();
 const settingsStore = useSettingsStore();
 const router = useRouter();
 
+// 付費偵測依 LLM provider id：openai / anthropic 為計費方案（無免費額度）；
+// groq / gemini 提供免費額度。Whisper 目前僅 Groq，一律視為免費額度。
+const isPaidWhisperProvider = computed(() => false);
+
 const isPaidLlmProvider = computed(() => {
-  const lConfig = findLlmModelConfig(settingsStore.selectedLlmModelId);
-  return (lConfig?.freeQuotaRpd ?? 0) === 0;
+  const providerId = settingsStore.selectedLlmProviderId;
+  // groq / gemini 提供免費額度；openai / anthropic 為計費方案
+  return providerId !== "groq" && providerId !== "gemini";
 });
+
+const hasAnyPaidProvider = computed(
+  () => isPaidWhisperProvider.value || isPaidLlmProvider.value,
+);
 
 const quotaDimensionList = computed(() => {
   const usage = historyStore.dashboardStats.dailyQuotaUsage;
-  const wConfig = findWhisperModelConfig(settingsStore.selectedWhisperModelId);
-  const lConfig = findLlmModelConfig(settingsStore.selectedLlmModelId);
+  const dimensionList: { remaining: number; label: string }[] = [];
 
-  const wRpdLimit = wConfig?.freeQuotaRpd ?? 2000;
-  const wAudioLimitMs = (wConfig?.freeQuotaAudioSecondsPerDay ?? 28800) * 1000;
+  // 免費 Whisper（Groq）才顯示額度維度；limit 為 0 的維度略過避免誤導
+  if (!isPaidWhisperProvider.value) {
+    const wConfig = findWhisperModelConfig(settingsStore.selectedWhisperModelId);
+    const wRpdLimit = wConfig?.freeQuotaRpd ?? 2000;
+    const wAudioLimitMs =
+      (wConfig?.freeQuotaAudioSecondsPerDay ?? 28800) * 1000;
+    if (wRpdLimit > 0) {
+      dimensionList.push({
+        remaining: 1 - usage.whisperRequestCount / wRpdLimit,
+        label: t("dashboard.quotaWhisperRequests", { used: usage.whisperRequestCount, limit: formatNumber(wRpdLimit) }),
+      });
+    }
+    if (wAudioLimitMs > 0) {
+      dimensionList.push({
+        remaining: 1 - usage.whisperBilledAudioMs / wAudioLimitMs,
+        label: t("dashboard.quotaAudio", { used: formatDurationFromMs(usage.whisperBilledAudioMs), limit: formatDurationFromMs(wAudioLimitMs) }),
+      });
+    }
+  }
 
-  const dimensionList = [
-    {
-      remaining: wRpdLimit > 0 ? 1 - usage.whisperRequestCount / wRpdLimit : 0,
-      label: t("dashboard.quotaWhisperRequests", { used: usage.whisperRequestCount, limit: formatNumber(wRpdLimit) }),
-    },
-    {
-      remaining: wAudioLimitMs > 0 ? 1 - usage.whisperBilledAudioMs / wAudioLimitMs : 0,
-      label: t("dashboard.quotaAudio", { used: formatDurationFromMs(usage.whisperBilledAudioMs), limit: formatDurationFromMs(wAudioLimitMs) }),
-    },
-  ];
-
-  // 付費 provider 無免費額度，不顯示 LLM 額度進度條
+  // 免費 LLM（Groq/Gemini）才顯示額度維度
   if (!isPaidLlmProvider.value) {
+    const lConfig = findLlmModelConfig(settingsStore.selectedLlmModelId);
     const lRpdLimit = lConfig?.freeQuotaRpd ?? 1000;
     const lTpdLimit = lConfig?.freeQuotaTpd ?? 100_000;
-    dimensionList.push(
-      {
-        remaining: lRpdLimit > 0 ? 1 - usage.llmRequestCount / lRpdLimit : 0,
+    if (lRpdLimit > 0) {
+      dimensionList.push({
+        remaining: 1 - usage.llmRequestCount / lRpdLimit,
         label: t("dashboard.quotaLlmRequests", { used: usage.llmRequestCount, limit: formatNumber(lRpdLimit) }),
-      },
-      {
-        remaining: lTpdLimit > 0 ? 1 - usage.llmTotalTokens / lTpdLimit : 0,
+      });
+    }
+    if (lTpdLimit > 0) {
+      dimensionList.push({
+        remaining: 1 - usage.llmTotalTokens / lTpdLimit,
         label: t("dashboard.quotaLlmTokens", { used: formatNumber(usage.llmTotalTokens), limit: formatNumber(lTpdLimit) }),
-      },
-    );
+      });
+    }
   }
 
   return dimensionList;
 });
 
+const hasFreeQuota = computed(() => quotaDimensionList.value.length > 0);
+
+// 計費方案（OpenAI/Anthropic）無免費額度，改顯示今日實際用量
+const paidUsageList = computed(() => {
+  const usage = historyStore.dashboardStats.dailyQuotaUsage;
+  const list: { label: string }[] = [];
+  if (isPaidWhisperProvider.value) {
+    list.push({
+      label: t("dashboard.usageWhisper", {
+        requests: formatNumber(usage.whisperRequestCount),
+        audio: formatDurationFromMs(usage.whisperBilledAudioMs),
+      }),
+    });
+  }
+  if (isPaidLlmProvider.value) {
+    list.push({
+      label: t("dashboard.usageLlm", {
+        requests: formatNumber(usage.llmRequestCount),
+        tokens: formatNumber(usage.llmTotalTokens),
+      }),
+    });
+  }
+  return list;
+});
+
 const quotaRemainingPercent = computed(() => {
+  if (quotaDimensionList.value.length === 0) return 0;
   const minRemaining = Math.min(...quotaDimensionList.value.map((d) => d.remaining));
   return Math.max(0, minRemaining);
 });
 
 const quotaBottleneckLabel = computed(() => {
+  if (quotaDimensionList.value.length === 0) return "";
   const sorted = [...quotaDimensionList.value].sort((a, b) => a.remaining - b.remaining);
   return sorted[0].label;
 });
@@ -193,28 +237,57 @@ onBeforeUnmount(() => {
           <TooltipTrigger as-child>
             <Card class="cursor-default">
               <CardHeader class="pb-2">
-                <CardDescription>{{ $t("dashboard.dailyQuota") }}</CardDescription>
+                <div class="flex items-center justify-between gap-2">
+                  <CardDescription>{{ hasFreeQuota ? $t("dashboard.dailyQuota") : $t("dashboard.dailyUsage") }}</CardDescription>
+                  <Badge v-if="hasAnyPaidProvider" variant="secondary">{{ $t("dashboard.billedPlan") }}</Badge>
+                </div>
               </CardHeader>
               <CardContent>
-                <p class="text-2xl font-bold text-foreground">
-                  {{ Math.round(quotaRemainingPercent * 100) }}%
-                </p>
-                <div class="mt-2 h-1.5 w-full rounded-full bg-muted">
-                  <div
-                    class="h-full rounded-full transition-all"
-                    :class="quotaBarColorClass"
-                    :style="{ width: `${Math.round(quotaRemainingPercent * 100)}%` }"
-                  />
+                <!-- 免費額度（免費服務）-->
+                <template v-if="hasFreeQuota">
+                  <p class="text-2xl font-bold text-foreground">
+                    {{ Math.round(quotaRemainingPercent * 100) }}%
+                  </p>
+                  <div class="mt-2 h-1.5 w-full rounded-full bg-muted">
+                    <div
+                      class="h-full rounded-full transition-all"
+                      :class="quotaBarColorClass"
+                      :style="{ width: `${Math.round(quotaRemainingPercent * 100)}%` }"
+                    />
+                  </div>
+                  <p class="text-xs text-muted-foreground mt-1.5 truncate">
+                    {{ quotaBottleneckLabel }}
+                  </p>
+                </template>
+
+                <!-- 付費服務今日用量（混用與全付費共用同一段；混用為次要樣式 + 分隔線）-->
+                <div
+                  v-if="paidUsageList.length > 0"
+                  class="space-y-1"
+                  :class="hasFreeQuota ? 'mt-1.5 pt-1.5 border-t border-border' : ''"
+                >
+                  <p
+                    v-for="(item, idx) in paidUsageList"
+                    :key="idx"
+                    :class="hasFreeQuota ? 'text-xs text-muted-foreground' : 'text-sm font-medium text-foreground'"
+                  >
+                    {{ item.label }}
+                  </p>
                 </div>
-                <p class="text-xs text-muted-foreground mt-1.5 truncate">
-                  {{ quotaBottleneckLabel }}
+
+                <!-- 全付費提示（混用不顯示，避免與免費額度 % 矛盾）-->
+                <p
+                  v-if="!hasFreeQuota && paidUsageList.length > 0"
+                  class="text-xs text-muted-foreground mt-1.5"
+                >
+                  {{ $t("dashboard.billedNoFreeQuota") }}
                 </p>
               </CardContent>
             </Card>
           </TooltipTrigger>
           <TooltipContent class="w-72 p-3 bg-card text-card-foreground border border-border" side="bottom" :side-offset="6" hide-arrow>
-            <p class="text-xs font-medium mb-2">{{ $t("dashboard.dailyQuotaDetail") }}</p>
-            <div class="space-y-2">
+            <p class="text-xs font-medium mb-2">{{ hasFreeQuota ? $t("dashboard.dailyQuotaDetail") : $t("dashboard.dailyUsage") }}</p>
+            <div v-if="hasFreeQuota" class="space-y-2">
               <div v-for="(dim, idx) in quotaDimensionList" :key="idx">
                 <div class="flex items-center justify-between text-xs">
                   <span class="text-muted-foreground">{{ dim.label }}</span>
@@ -228,6 +301,20 @@ onBeforeUnmount(() => {
                   />
                 </div>
               </div>
+            </div>
+            <div
+              v-if="paidUsageList.length > 0"
+              class="space-y-1"
+              :class="{ 'mt-2 pt-2 border-t border-border': hasFreeQuota }"
+            >
+              <div
+                v-for="(item, idx) in paidUsageList"
+                :key="`paid-${idx}`"
+                class="text-xs text-muted-foreground"
+              >
+                {{ item.label }}
+              </div>
+              <p class="text-xs text-muted-foreground">{{ $t("dashboard.billedNoFreeQuota") }}</p>
             </div>
             <div
               v-if="historyStore.dashboardStats.dailyQuotaUsage.vocabularyAnalysisRequestCount > 0"

--- a/tests/component/DashboardView.test.ts
+++ b/tests/component/DashboardView.test.ts
@@ -1,0 +1,129 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import i18n from "../../src/i18n";
+import DashboardView from "../../src/views/DashboardView.vue";
+
+vi.mock("../../src/composables/useTauriEvents", () => ({
+  listenToEvent: vi.fn().mockResolvedValue(vi.fn()),
+  TRANSCRIPTION_COMPLETED: "transcription:completed",
+}));
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("../../src/lib/sentry", () => ({
+  captureError: vi.fn(),
+}));
+
+let settingsState: Record<string, unknown>;
+let historyState: Record<string, unknown>;
+
+vi.mock("../../src/stores/useSettingsStore", () => ({
+  useSettingsStore: () => settingsState,
+}));
+
+vi.mock("../../src/stores/useHistoryStore", () => ({
+  useHistoryStore: () => historyState,
+}));
+
+function makeHistory(usage: Record<string, number> = {}) {
+  return {
+    dashboardStats: {
+      totalRecordingDurationMs: 0,
+      totalCharacters: 0,
+      estimatedTimeSavedMs: 0,
+      totalTranscriptions: 0,
+      dailyQuotaUsage: {
+        whisperRequestCount: 0,
+        whisperBilledAudioMs: 0,
+        llmRequestCount: 0,
+        llmTotalTokens: 0,
+        vocabularyAnalysisRequestCount: 0,
+        vocabularyAnalysisTotalTokens: 0,
+        ...usage,
+      },
+    },
+    dailyUsageTrendList: [],
+    recentTranscriptionList: [],
+    refreshDashboard: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeSettings(overrides: Record<string, unknown> = {}) {
+  return {
+    selectedLlmProviderId: "groq",
+    selectedWhisperModelId: "whisper-large-v3",
+    selectedLlmModelId: "llama-3.3-70b-versatile",
+    ...overrides,
+  };
+}
+
+const passThroughStub = { template: "<div><slot /></div>" };
+
+// renderTooltip=false 時 TooltipContent 不渲染 slot → 只測「卡片主體」；
+// renderTooltip=true 時渲染 tooltip 內容 → 測 tooltip 行為。
+function mountDashboard(renderTooltip = false) {
+  return mount(DashboardView, {
+    global: {
+      plugins: [i18n],
+      stubs: {
+        DashboardUsageChart: true,
+        TooltipProvider: passThroughStub,
+        Tooltip: passThroughStub,
+        TooltipTrigger: passThroughStub,
+        TooltipContent: renderTooltip ? passThroughStub : { template: "<div />" },
+      },
+    },
+  });
+}
+
+describe("DashboardView 額度卡片", () => {
+  beforeEach(() => {
+    i18n.global.locale.value = "zh-TW";
+    historyState = makeHistory({ whisperRequestCount: 10, llmRequestCount: 5 });
+  });
+
+  it("[P0] 全免費 provider：主體顯示剩餘免費額度百分比，無計費標籤", () => {
+    settingsState = makeSettings();
+    const text = mountDashboard().text();
+
+    expect(text).toContain("今日剩餘免費額度");
+    expect(text).toContain("%");
+    expect(text).not.toContain("計費");
+    expect(text).not.toContain("今日用量");
+  });
+
+  it("[P0] 混用（免費 Whisper + 計費 OpenAI LLM）：主體同時顯示免費 % 與付費 LLM 用量行，但不含無額度提示", () => {
+    settingsState = makeSettings({
+      selectedLlmProviderId: "openai",
+    });
+    historyState = makeHistory({
+      whisperRequestCount: 10,
+      llmRequestCount: 8,
+      llmTotalTokens: 4500,
+    });
+    const text = mountDashboard().text();
+
+    expect(text).toContain("今日剩餘免費額度");
+    expect(text).toContain("%");
+    expect(text).toContain("計費");
+    // 付費 LLM 用量行（含實際數字）出現在卡片主體（不再只在 tooltip）
+    expect(text).toContain("LLM：8 次 · 4,500 tokens");
+    // 混用主體不應顯示「無免費額度」提示（與免費 % 矛盾）
+    expect(text).not.toContain("付費方案 — 無免費額度限制");
+    expect(text).not.toContain("Infinity");
+  });
+
+  it("[P0] 混用 tooltip 仍保留付費用量與無額度提示", () => {
+    settingsState = makeSettings({
+      selectedLlmProviderId: "openai",
+    });
+    historyState = makeHistory({ llmRequestCount: 8, llmTotalTokens: 4500 });
+    // renderTooltip=true → tooltip 內容會被渲染
+    const text = mountDashboard(true).text();
+
+    expect(text).toContain("付費方案 — 無免費額度限制");
+    expect(text).toContain("LLM");
+  });
+});


### PR DESCRIPTION
## 摘要 / Summary

One of **4 PRs replacing #46** (splitting it into independent PRs as requested in #47). This is the **Dashboard display change** ② — show today's usage for billed LLM providers instead of a misleading free-quota bar.

For billed LLM providers (**OpenAI / Anthropic**) there is no free daily quota, so the "remaining free quota" percentage bar was misleading. This detects billed providers and shows **today's actual usage** (requests / tokens) instead. Mixed setups (free Groq Whisper + billed LLM) show **both** the free % and a billed usage row. Whisper stays on the free Groq quota.

## Changes
- `isPaidLlmProvider` detection: `openai` / `anthropic` are billed; `groq` / `gemini` are free.
- Card body surfaces billed usage rows for mixed providers; the tooltip keeps the "no free quota" note.
- i18n for today's-usage labels across all 5 locales.
- Component tests for free / mixed-provider / tooltip cases.

Frontend-only; no Rust changes.

> Splitting **#46** per #47 into: ① Azure provider (API-key only) · **② this dashboard change** · ③ transcription rustls · ④ clippy cleanup (#57). Rebased onto `main` and de-coupled from the Azure provider (billing detection is purely OpenAI/Anthropic-based).
