### PR TITLE
fix(database): connection-pool-safe migrations + DATABASE_READY handshake (independent of #48)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,7 +7,12 @@ import { useVoiceFlowStore } from "./stores/useVoiceFlowStore";
 import { useSettingsStore } from "./stores/useSettingsStore";
 import { useVocabularyStore } from "./stores/useVocabularyStore";
 import { connectToDatabase } from "./lib/database";
-import { listenToEvent, SETTINGS_UPDATED, VOCABULARY_CHANGED } from "./composables/useTauriEvents";
+import {
+  listenToEvent,
+  SETTINGS_UPDATED,
+  VOCABULARY_CHANGED,
+  waitForDatabaseReady,
+} from "./composables/useTauriEvents";
 import { useI18n } from "vue-i18n";
 
 const { t } = useI18n();
@@ -37,6 +42,13 @@ onMounted(async () => {
   // 初始化 DB（供 vocabularyStore 使用）
   let isDatabaseReady = false;
   try {
+    // 等 Dashboard 完成 migration 再存取連線池，避免併發破壞 migration。
+    // 逾時（Dashboard 缺席或 migration 過久）才 fallback 直接連線；
+    // connectToDatabase() 自帶 retry，HUD 的 DB 讀取亦各有錯誤處理。
+    const databaseReady = await waitForDatabaseReady();
+    if (!databaseReady) {
+      console.warn("[App] DATABASE_READY 逾時，改用 connectToDatabase fallback");
+    }
     await connectToDatabase();
     isDatabaseReady = true;
   } catch (err) {

--- a/src/composables/useTauriEvents.ts
+++ b/src/composables/useTauriEvents.ts
@@ -1,3 +1,5 @@
+import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
+
 export {
   emit as emitEvent,
   emitTo as emitToWindow,
@@ -25,3 +27,48 @@ export const ESCAPE_PRESSED = "escape:pressed" as const;
 export const HOTKEY_MODE_TOGGLE = "hotkey:mode-toggle" as const;
 export const HOTKEY_RECORDING_CAPTURED = "hotkey:recording-captured" as const;
 export const HOTKEY_RECORDING_REJECTED = "hotkey:recording-rejected" as const;
+
+// Dashboard 完成 DB migration 後廣播；HUD 收到才開始存取連線池
+export const DATABASE_READY = "database:ready" as const;
+// HUD 請 Dashboard 重新廣播 DATABASE_READY（解決事件早於監聽的競態）
+export const DATABASE_READY_PING = "database:ready-ping" as const;
+
+/**
+ * HUD 等待 Dashboard 完成資料庫 migration 後再存取連線池。
+ *
+ * 動機：tauri-plugin-sql 連線池無連線親和性，若 HUD 在 Dashboard 跑
+ * migration 時併發存取同一個 pool，會強迫 pool 多開一條連線，破壞
+ * migration 的跨語句假設（曾導致 "cannot commit - no transaction is active"）。
+ *
+ * 以 ping/replay 解決「Dashboard 早於 HUD 監聽就已廣播」的競態；逾時則
+ * 回傳 false，呼叫端可 fallback 至 connectToDatabase() 的 retry 迴圈
+ *（Dashboard 缺席或 init 失敗時 HUD 仍可嘗試自行連線）。
+ */
+export async function waitForDatabaseReady(timeoutMs = 8000): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    let unlisten: UnlistenFn | null = null;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const finish = (ready: boolean) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      if (unlisten) unlisten();
+      resolve(ready);
+    };
+
+    void listen(DATABASE_READY, () => finish(true)).then((fn) => {
+      unlisten = fn;
+      // 監聽建立前就逾時：立即解除剛建立的監聽
+      if (settled) {
+        fn();
+        return;
+      }
+      // 監聽就緒後請 Dashboard 重新廣播，補捉早於監聽的 ready 事件
+      void emit(DATABASE_READY_PING);
+    });
+
+    timer = setTimeout(() => finish(false), timeoutMs);
+  });
+}

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -200,8 +200,7 @@ async function doInitializeDatabase(): Promise<Database> {
   const v3CurrentVersion = v3VersionRows[0]?.version ?? 1;
 
   if (v3CurrentVersion < 3) {
-    // DDL（ALTER TABLE ADD COLUMN）必須在 transaction 外執行
-    // tauri-plugin-sql 驅動下，DDL 在顯式 transaction 內對後續語句不可見
+    // 先補上 weight/source 欄位，後續建立 idx_vocabulary_weight 才看得到 weight
     await addColumnIfNotExists(
       connection,
       "vocabulary",
@@ -213,59 +212,61 @@ async function doInitializeDatabase(): Promise<Database> {
       "source TEXT NOT NULL DEFAULT 'manual'",
     );
 
-    await connection.execute("BEGIN TRANSACTION;");
-    try {
-      await connection.execute(
-        "CREATE INDEX IF NOT EXISTS idx_vocabulary_weight ON vocabulary(weight DESC);",
-      );
+    // 不使用顯式交易：tauri-plugin-sql 連線池無連線親和性，
+    // 跨 execute() 呼叫的 BEGIN/COMMIT 會落在不同連線而失敗
+    // （cannot commit - no transaction is active）。改為依賴冪等語句 +
+    // 下方關鍵表恢復邏輯確保可重複執行。
+    await connection.execute(
+      "CREATE INDEX IF NOT EXISTS idx_vocabulary_weight ON vocabulary(weight DESC);",
+    );
 
-      // api_usage 表重建（擴展 CHECK constraint 加入 'vocabulary_analysis'）
-      // SQLite 不支援 ALTER CONSTRAINT，必須重建
-      // 清除上次失敗可能殘留的暫存表
-      await connection.execute("DROP TABLE IF EXISTS api_usage_new;");
-      await connection.execute(`
-        CREATE TABLE api_usage_new (
-          id TEXT PRIMARY KEY,
-          transcription_id TEXT NOT NULL,
-          api_type TEXT NOT NULL CHECK(api_type IN ('whisper', 'chat', 'vocabulary_analysis')),
-          model TEXT NOT NULL,
-          prompt_tokens INTEGER,
-          completion_tokens INTEGER,
-          total_tokens INTEGER,
-          prompt_time_ms REAL,
-          completion_time_ms REAL,
-          total_time_ms REAL,
-          audio_duration_ms INTEGER,
-          estimated_cost_ceiling REAL,
-          created_at TEXT NOT NULL DEFAULT (datetime('now')),
-          FOREIGN KEY (transcription_id) REFERENCES transcriptions(id)
-        );
-      `);
-      // api_usage 可能在先前失敗的 migration 中被 DROP 而未 RENAME 回來
-      const hasApiUsage = await tableExists(connection, "api_usage");
-      if (hasApiUsage) {
-        await connection.execute(
-          "INSERT INTO api_usage_new SELECT * FROM api_usage;",
-        );
-        await connection.execute("DROP TABLE api_usage;");
-      }
-      await connection.execute(
-        "ALTER TABLE api_usage_new RENAME TO api_usage;",
-      );
-      await connection.execute(`
-        CREATE INDEX IF NOT EXISTS idx_api_usage_transcription_id
-        ON api_usage(transcription_id);
-      `);
-
-      await connection.execute(
-        "INSERT OR REPLACE INTO schema_version (version) VALUES (3);",
-      );
-
-      await connection.execute("COMMIT;");
-    } catch (migrationError) {
-      await connection.execute("ROLLBACK;");
-      throw migrationError;
+    // api_usage 表重建（擴展 CHECK constraint 加入 'vocabulary_analysis'）
+    // SQLite 不支援 ALTER CONSTRAINT，必須重建
+    // 若上次 rebuild 在 DROP api_usage 後、RENAME 前崩潰，api_usage_new 會是
+    // 唯一資料副本，先還原成 api_usage，避免被下方 DROP 清掉造成資料遺失
+    if (
+      !(await tableExists(connection, "api_usage")) &&
+      (await tableExists(connection, "api_usage_new"))
+    ) {
+      await connection.execute("ALTER TABLE api_usage_new RENAME TO api_usage;");
     }
+    // 清除上次失敗可能殘留的暫存表（此時 api_usage 必為資料來源，drop 安全）
+    await connection.execute("DROP TABLE IF EXISTS api_usage_new;");
+    await connection.execute(`
+      CREATE TABLE api_usage_new (
+        id TEXT PRIMARY KEY,
+        transcription_id TEXT NOT NULL,
+        api_type TEXT NOT NULL CHECK(api_type IN ('whisper', 'chat', 'vocabulary_analysis')),
+        model TEXT NOT NULL,
+        prompt_tokens INTEGER,
+        completion_tokens INTEGER,
+        total_tokens INTEGER,
+        prompt_time_ms REAL,
+        completion_time_ms REAL,
+        total_time_ms REAL,
+        audio_duration_ms INTEGER,
+        estimated_cost_ceiling REAL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (transcription_id) REFERENCES transcriptions(id)
+      );
+    `);
+    // api_usage 可能在先前失敗的 migration 中被 DROP 而未 RENAME 回來
+    const hasApiUsage = await tableExists(connection, "api_usage");
+    if (hasApiUsage) {
+      await connection.execute(
+        "INSERT INTO api_usage_new SELECT * FROM api_usage;",
+      );
+      await connection.execute("DROP TABLE api_usage;");
+    }
+    await connection.execute("ALTER TABLE api_usage_new RENAME TO api_usage;");
+    await connection.execute(`
+      CREATE INDEX IF NOT EXISTS idx_api_usage_transcription_id
+      ON api_usage(transcription_id);
+    `);
+
+    await connection.execute(
+      "INSERT OR REPLACE INTO schema_version (version) VALUES (3);",
+    );
 
     console.log(
       "[database] Migration v2 → v3: vocabulary weight/source + api_usage CHECK expansion",
@@ -279,7 +280,7 @@ async function doInitializeDatabase(): Promise<Database> {
   const v4CurrentVersion = v4VersionRows[0]?.version ?? 1;
 
   if (v4CurrentVersion < 4) {
-    // DDL（ALTER TABLE ADD COLUMN）必須在 transaction 外執行
+    // 先補上 audio_file_path/status 欄位，後續建立 idx_transcriptions_status 才看得到 status
     await addColumnIfNotExists(
       connection,
       "transcriptions",
@@ -291,19 +292,12 @@ async function doInitializeDatabase(): Promise<Database> {
       "status TEXT NOT NULL DEFAULT 'success'",
     );
 
-    await connection.execute("BEGIN TRANSACTION;");
-    try {
-      await connection.execute(
-        "CREATE INDEX IF NOT EXISTS idx_transcriptions_status ON transcriptions(status);",
-      );
-      await connection.execute(
-        "INSERT OR REPLACE INTO schema_version (version) VALUES (4);",
-      );
-      await connection.execute("COMMIT;");
-    } catch (migrationError) {
-      await connection.execute("ROLLBACK;");
-      throw migrationError;
-    }
+    await connection.execute(
+      "CREATE INDEX IF NOT EXISTS idx_transcriptions_status ON transcriptions(status);",
+    );
+    await connection.execute(
+      "INSERT OR REPLACE INTO schema_version (version) VALUES (4);",
+    );
     console.log(
       "[database] Migration v3 → v4: recording storage + status columns",
     );
@@ -316,29 +310,22 @@ async function doInitializeDatabase(): Promise<Database> {
   const v5CurrentVersion = v5VersionRows[0]?.version ?? 1;
 
   if (v5CurrentVersion < 5) {
-    await connection.execute("BEGIN TRANSACTION;");
-    try {
-      await connection.execute(`
-        CREATE TABLE IF NOT EXISTS hallucination_terms (
-          id TEXT PRIMARY KEY,
-          term TEXT NOT NULL UNIQUE,
-          source TEXT NOT NULL CHECK(source IN ('builtin', 'auto', 'manual')),
-          locale TEXT NOT NULL,
-          created_at TEXT NOT NULL DEFAULT (datetime('now'))
-        );
-      `);
-      await connection.execute(`
-        CREATE INDEX IF NOT EXISTS idx_hallucination_terms_locale
-        ON hallucination_terms(locale);
-      `);
-      await connection.execute(
-        "INSERT OR REPLACE INTO schema_version (version) VALUES (5);",
+    await connection.execute(`
+      CREATE TABLE IF NOT EXISTS hallucination_terms (
+        id TEXT PRIMARY KEY,
+        term TEXT NOT NULL UNIQUE,
+        source TEXT NOT NULL CHECK(source IN ('builtin', 'auto', 'manual')),
+        locale TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
       );
-      await connection.execute("COMMIT;");
-    } catch (migrationError) {
-      await connection.execute("ROLLBACK;");
-      throw migrationError;
-    }
+    `);
+    await connection.execute(`
+      CREATE INDEX IF NOT EXISTS idx_hallucination_terms_locale
+      ON hallucination_terms(locale);
+    `);
+    await connection.execute(
+      "INSERT OR REPLACE INTO schema_version (version) VALUES (5);",
+    );
     console.log("[database] Migration v4 → v5: hallucination_terms table");
   }
 
@@ -349,22 +336,15 @@ async function doInitializeDatabase(): Promise<Database> {
   const v6CurrentVersion = v6VersionRows[0]?.version ?? 1;
 
   if (v6CurrentVersion < 6) {
-    await connection.execute("BEGIN TRANSACTION;");
-    try {
-      await connection.execute(`
-        UPDATE transcriptions
-        SET char_count = LENGTH(raw_text)
-        WHERE processed_text IS NOT NULL
-          AND char_count != LENGTH(raw_text);
-      `);
-      await connection.execute(
-        "INSERT OR REPLACE INTO schema_version (version) VALUES (6);",
-      );
-      await connection.execute("COMMIT;");
-    } catch (migrationError) {
-      await connection.execute("ROLLBACK;");
-      throw migrationError;
-    }
+    await connection.execute(`
+      UPDATE transcriptions
+      SET char_count = LENGTH(raw_text)
+      WHERE processed_text IS NOT NULL
+        AND char_count != LENGTH(raw_text);
+    `);
+    await connection.execute(
+      "INSERT OR REPLACE INTO schema_version (version) VALUES (6);",
+    );
     console.log(
       "[database] Migration v5 → v6: recalculate char_count from raw_text",
     );
@@ -377,17 +357,10 @@ async function doInitializeDatabase(): Promise<Database> {
   const v7CurrentVersion = v7VersionRows[0]?.version ?? 1;
 
   if (v7CurrentVersion < 7) {
-    await connection.execute("BEGIN TRANSACTION;");
-    try {
-      await connection.execute("DROP TABLE IF EXISTS hallucination_terms;");
-      await connection.execute(
-        "INSERT OR REPLACE INTO schema_version (version) VALUES (7);",
-      );
-      await connection.execute("COMMIT;");
-    } catch (migrationError) {
-      await connection.execute("ROLLBACK;");
-      throw migrationError;
-    }
+    await connection.execute("DROP TABLE IF EXISTS hallucination_terms;");
+    await connection.execute(
+      "INSERT OR REPLACE INTO schema_version (version) VALUES (7);",
+    );
     console.log(
       "[database] Migration v6 → v7: removed hallucination_terms table",
     );

--- a/src/main-window.ts
+++ b/src/main-window.ts
@@ -5,6 +5,12 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import MainApp from "./MainApp.vue";
 import router from "./router";
 import { initializeDatabase, setDatabaseInitError } from "./lib/database";
+import {
+  emitEvent,
+  listenToEvent,
+  DATABASE_READY,
+  DATABASE_READY_PING,
+} from "./composables/useTauriEvents";
 import { extractErrorMessage } from "./lib/errorUtils";
 import { initSentryForDashboard, captureError } from "./lib/sentry";
 import { useSettingsStore } from "./stores/useSettingsStore";
@@ -34,6 +40,11 @@ async function bootstrap() {
   // DB 必須在 mount 之前初始化，否則 View 的 onMounted 會因 getDatabase() 拋錯而全部失敗
   try {
     await initializeDatabase();
+    // migration 完成：先註冊 ping 回應再廣播，通知 HUD 可安全存取連線池
+    await listenToEvent(DATABASE_READY_PING, () => {
+      void emitEvent(DATABASE_READY);
+    });
+    await emitEvent(DATABASE_READY);
   } catch (err) {
     const message = extractErrorMessage(err);
     console.error("[main-window] Database init failed:", message);

--- a/tests/unit/database-transaction-safety.test.ts
+++ b/tests/unit/database-transaction-safety.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+/**
+ * 回歸守門：禁止以「獨立 execute() 呼叫」發出 BEGIN/COMMIT/ROLLBACK。
+ *
+ * tauri-plugin-sql 每次 execute()/select() 都從 sqlx 連線池借一條全新連線，
+ * 無連線親和性；跨呼叫的 BEGIN 與 COMMIT 可能落在不同實體連線，導致
+ * "cannot commit - no transaction is active"（首次啟動跑 migration 必現）。
+ * Migration / 批次寫入必須改用冪等語句，不可依賴跨呼叫交易。
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..");
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(repoRoot, relativePath), "utf8");
+}
+
+describe("DB 連線池安全：禁止跨呼叫交易語句", () => {
+  const files = ["src/lib/database.ts", "src/stores/useVocabularyStore.ts"];
+
+  for (const file of files) {
+    it(`[P1] ${file} 不得有獨立的 execute("BEGIN/COMMIT/ROLLBACK") 呼叫`, () => {
+      const source = readSource(file);
+      // 全檔掃描（\s* 可跨換行），亦能捕捉跨行的 .execute(\n  "COMMIT"\n)
+      const pattern =
+        /\.execute\(\s*[`"'](?:BEGIN(?:\s+TRANSACTION)?|COMMIT|ROLLBACK)\b/gi;
+      const offending = [...source.matchAll(pattern)].map((match) => {
+        const lineNo = source.slice(0, match.index).split("\n").length;
+        return `L${lineNo}: ${match[0]}`;
+      });
+
+      expect(
+        offending,
+        `發現跨呼叫交易語句（連線池無親和性，COMMIT 可能落在無交易的連線）：\n${offending.join(
+          "\n",
+        )}`,
+      ).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## 摘要 / Summary

Independent, rebased-onto-`main` version of **#48** (part of splitting the stacked chain #46–#55 into standalone PRs, as requested in #47). Fixes the long-standing "database init failed / startup lock conflict" by removing the reliance on **cross-`execute()` transactions** that the pooled `tauri-plugin-sql` connection can't honor.

## Problem
`tauri-plugin-sql`'s sqlx pool has **no connection affinity** — every `execute()` / `select()` borrows a fresh physical connection. Two places relied on cross-call transactions:
1. **Schema migrations** wrapped multiple DDL/DML in `BEGIN … COMMIT`, but `BEGIN` and `COMMIT` could land on different connections → first launch could throw `cannot commit - no transaction is active`, failing the whole init.
2. **Dual-window concurrent init** — HUD + Dashboard both hit the pool at startup; HUD borrowing a connection during Dashboard's migration forced extra connections open and broke the migration's cross-statement assumptions (lock conflict).

This is the root cause behind the repeatedly-reported #14 / #9 / #4 startup issues that were only partially mitigated before.

## Fix (2 commits)
1. **`fix(database): make schema migrations connection-pool safe`** — removes cross-call `BEGIN/COMMIT/ROLLBACK` from migrations, replacing atomicity with **idempotent statements + crash-recovery** (the `api_usage` rebuild uses a rename-back ordering so a crash mid-migration can't lose data). Adds `tests/unit/database-transaction-safety.test.ts` — a regression guard forbidding standalone `BEGIN/COMMIT/ROLLBACK` in `database.ts` / `useVocabularyStore.ts`.
2. **`fix(database): gate HUD pool access on Dashboard migration via DATABASE_READY`** — new `DATABASE_READY` / `DATABASE_READY_PING` events: Dashboard broadcasts after migration; the HUD `waitForDatabaseReady()` (ping-replay to fix the "event before listener" race + timeout fallback) waits before connecting. Complements (not replaces) the existing `initPromise` + `busy_timeout`.

Frontend-only; no Rust or schema-version changes.

> Replaces **#48**. The vocabulary-import transaction fix that was bundled here in the old stack isn't needed on `main` (that `importEntries` path arrives with the dictionary/backup PRs), so this PR is scoped purely to migration safety + the DATABASE_READY handshake. The regression test passes standalone (`useVocabularyStore` is already transaction-free on `main`).
