### PR TITLE
feat(azure): Azure / Microsoft Foundry provider — API-key auth (split 1/4 of #46)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,10 @@
 {
   "identifier": "default",
   "description": "Default capability for the main window",
-  "windows": ["main", "main-window"],
+  "windows": [
+    "main",
+    "main-window"
+  ],
   "permissions": [
     "core:default",
     "core:window:default",
@@ -34,6 +37,15 @@
         },
         {
           "url": "https://generativelanguage.googleapis.com/*"
+        },
+        {
+          "url": "https://*.openai.azure.com/*"
+        },
+        {
+          "url": "https://*.services.ai.azure.com/*"
+        },
+        {
+          "url": "https://*.cognitiveservices.azure.com/*"
         }
       ]
     },

--- a/src-tauri/src/plugins/transcription.rs
+++ b/src-tauri/src/plugins/transcription.rs
@@ -42,9 +42,9 @@ pub enum TranscriptionError {
     FileTooLarge { size_mb: f64, limit_mb: usize },
     #[error("API key is missing")]
     ApiKeyMissing,
-    #[error("Groq API request failed: {0}")]
+    #[error("Transcription API request failed: {0}")]
     RequestFailed(String),
-    #[error("Groq API returned error ({0}): {1}")]
+    #[error("Transcription API error ({0}): {1}")]
     ApiError(u16, String),
     #[error("Failed to parse API response: {0}")]
     ParseError(String),
@@ -95,6 +95,46 @@ fn format_whisper_prompt(term_list: &[String]) -> String {
     format!("Important Vocabulary: {}", terms.join(", "))
 }
 
+const DEFAULT_AZURE_WHISPER_API_VERSION: &str = "2024-06-01";
+
+/// Azure OpenAI Whisper（deployment-path）轉錄設定。
+struct AzureWhisperConfig {
+    endpoint: String,
+    deployment: String,
+    api_version: String,
+}
+
+/// 依 provider 參數建出 Azure 設定；非 azure 回 None。
+fn build_azure_whisper_config(
+    provider: Option<String>,
+    endpoint: Option<String>,
+    deployment: Option<String>,
+    api_version: Option<String>,
+) -> Result<Option<AzureWhisperConfig>, TranscriptionError> {
+    if provider.as_deref() != Some("azure") {
+        return Ok(None);
+    }
+    let endpoint = endpoint
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| TranscriptionError::RequestFailed("Azure endpoint missing".to_string()))?;
+    let deployment = deployment
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            TranscriptionError::RequestFailed("Azure whisper deployment missing".to_string())
+        })?;
+    let api_version = api_version
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_AZURE_WHISPER_API_VERSION.to_string());
+    Ok(Some(AzureWhisperConfig {
+        endpoint,
+        deployment,
+        api_version,
+    }))
+}
+
 // ========== Shared Transcription Logic ==========
 
 async fn send_transcription_request(
@@ -104,6 +144,7 @@ async fn send_transcription_request(
     vocabulary_term_list: Option<Vec<String>>,
     model_id: Option<String>,
     language: Option<String>,
+    azure: Option<AzureWhisperConfig>,
 ) -> Result<TranscriptionResult, TranscriptionError> {
     if wav_data.len() < MINIMUM_AUDIO_SIZE {
         return Err(TranscriptionError::AudioTooSmall(wav_data.len()));
@@ -117,9 +158,24 @@ async fn send_transcription_request(
 
     let model = model_id.unwrap_or_else(|| DEFAULT_WHISPER_MODEL_ID.to_string());
 
+    let (url, include_model) = match &azure {
+        Some(cfg) => {
+            let base = cfg.endpoint.trim_end_matches('/');
+            (
+                format!(
+                    "{}/openai/deployments/{}/audio/transcriptions?api-version={}",
+                    base, cfg.deployment, cfg.api_version
+                ),
+                false,
+            )
+        }
+        None => (GROQ_API_URL.to_string(), true),
+    };
+
     println!(
-        "[transcription] Sending {} bytes WAV to Groq API (model={})",
+        "[transcription] Sending {} bytes WAV to {} (model={})",
         wav_data.len(),
+        if azure.is_some() { "Azure" } else { "Groq" },
         model
     );
 
@@ -133,8 +189,12 @@ async fn send_transcription_request(
 
     let mut form = reqwest::multipart::Form::new()
         .part("file", file_part)
-        .text("model", model)
         .text("response_format", "verbose_json");
+
+    // Azure deployment-path 不需要 model 欄位（部署已在 URL）
+    if include_model {
+        form = form.text("model", model);
+    }
 
     // Conditionally add language — None means auto-detect
     if let Some(lang) = language {
@@ -149,10 +209,13 @@ async fn send_transcription_request(
     }
 
     // Send request (reuse shared client for connection pooling)
-    let response = transcription_state
-        .client
-        .post(GROQ_API_URL)
-        .bearer_auth(&api_key)
+    let mut request_builder = transcription_state.client.post(&url);
+    request_builder = if azure.is_some() {
+        request_builder.header("api-key", &api_key)
+    } else {
+        request_builder.bearer_auth(&api_key)
+    };
+    let response = request_builder
         .multipart(form)
         .send()
         .await
@@ -205,6 +268,7 @@ async fn send_transcription_request(
 // ========== Commands ==========
 
 #[command]
+#[allow(clippy::too_many_arguments)]
 pub async fn transcribe_audio(
     state: State<'_, AudioRecorderState>,
     transcription_state: State<'_, TranscriptionState>,
@@ -212,10 +276,16 @@ pub async fn transcribe_audio(
     vocabulary_term_list: Option<Vec<String>>,
     model_id: Option<String>,
     language: Option<String>,
+    provider: Option<String>,
+    endpoint: Option<String>,
+    deployment: Option<String>,
+    api_version: Option<String>,
 ) -> Result<TranscriptionResult, TranscriptionError> {
     if api_key.trim().is_empty() {
         return Err(TranscriptionError::ApiKeyMissing);
     }
+
+    let azure = build_azure_whisper_config(provider, endpoint, deployment, api_version)?;
 
     // Take WAV data from shared state (consume it)
     let wav_data = {
@@ -233,11 +303,13 @@ pub async fn transcribe_audio(
         vocabulary_term_list,
         model_id,
         language,
+        azure,
     )
     .await
 }
 
 #[command]
+#[allow(clippy::too_many_arguments)]
 pub async fn retranscribe_from_file(
     transcription_state: State<'_, TranscriptionState>,
     file_path: String,
@@ -245,16 +317,21 @@ pub async fn retranscribe_from_file(
     vocabulary_term_list: Option<Vec<String>>,
     model_id: Option<String>,
     language: Option<String>,
+    provider: Option<String>,
+    endpoint: Option<String>,
+    deployment: Option<String>,
+    api_version: Option<String>,
 ) -> Result<TranscriptionResult, TranscriptionError> {
     if api_key.trim().is_empty() {
         return Err(TranscriptionError::ApiKeyMissing);
     }
 
+    let azure = build_azure_whisper_config(provider, endpoint, deployment, api_version)?;
+
     // 注意：std::fs::read 是同步 I/O，但 WAV 檔案通常很小（< 1MB），
     // 在 Tauri command 的 async context 中可接受。
-    let wav_data = std::fs::read(&file_path).map_err(|e| {
-        TranscriptionError::RequestFailed(format!("Failed to read WAV file: {e}"))
-    })?;
+    let wav_data = std::fs::read(&file_path)
+        .map_err(|e| TranscriptionError::RequestFailed(format!("Failed to read WAV file: {e}")))?;
 
     println!(
         "[transcription] Retranscribing from file: {} ({} bytes)",
@@ -269,28 +346,44 @@ pub async fn retranscribe_from_file(
         vocabulary_term_list,
         model_id,
         language,
+        azure,
     )
     .await
 }
 
 #[command]
+#[allow(clippy::too_many_arguments)]
 pub async fn test_whisper_connection(
     transcription_state: State<'_, TranscriptionState>,
     api_key: String,
     model_id: Option<String>,
+    provider: Option<String>,
+    endpoint: Option<String>,
+    deployment: Option<String>,
+    api_version: Option<String>,
 ) -> Result<(), TranscriptionError> {
     if api_key.trim().is_empty() {
         return Err(TranscriptionError::ApiKeyMissing);
     }
+
+    let azure = build_azure_whisper_config(provider, endpoint, deployment, api_version)?;
 
     // 1 秒 16kHz silence ≈ 32044 bytes，遠超過 MINIMUM_AUDIO_SIZE 的 1000 byte 下限。
     let silence_samples = vec![0i16; 16_000];
     let wav_data = super::audio_recorder::encode_wav(&silence_samples, 16_000)
         .map_err(|e| TranscriptionError::RequestFailed(e.to_string()))?;
 
-    send_transcription_request(wav_data, &transcription_state, api_key, None, model_id, None)
-        .await
-        .map(|_| ())
+    send_transcription_request(
+        wav_data,
+        &transcription_state,
+        api_key,
+        None,
+        model_id,
+        None,
+        azure,
+    )
+    .await
+    .map(|_| ())
 }
 
 // ========== Tests ==========
@@ -339,5 +432,63 @@ mod tests {
         assert!(json.contains("\"rawText\""));
         assert!(json.contains("\"transcriptionDurationMs\""));
         assert!(json.contains("\"noSpeechProbability\""));
+    }
+
+    #[test]
+    fn test_build_azure_whisper_config_non_azure() {
+        assert!(build_azure_whisper_config(None, None, None, None)
+            .unwrap()
+            .is_none());
+        assert!(
+            build_azure_whisper_config(Some("groq".to_string()), None, None, None)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_build_azure_whisper_config_full() {
+        let cfg = build_azure_whisper_config(
+            Some("azure".to_string()),
+            Some("https://r.openai.azure.com/".to_string()),
+            Some("whisper".to_string()),
+            Some("2024-10-21".to_string()),
+        )
+        .unwrap()
+        .expect("expected Some config");
+        assert_eq!(cfg.endpoint, "https://r.openai.azure.com/");
+        assert_eq!(cfg.deployment, "whisper");
+        assert_eq!(cfg.api_version, "2024-10-21");
+    }
+
+    #[test]
+    fn test_build_azure_whisper_config_defaults_and_key_mode() {
+        let cfg = build_azure_whisper_config(
+            Some("azure".to_string()),
+            Some("https://r.openai.azure.com".to_string()),
+            Some("whisper".to_string()),
+            None,
+        )
+        .unwrap()
+        .expect("expected Some config");
+        assert_eq!(cfg.api_version, DEFAULT_AZURE_WHISPER_API_VERSION);
+    }
+
+    #[test]
+    fn test_build_azure_whisper_config_missing_fields_err() {
+        assert!(build_azure_whisper_config(
+            Some("azure".to_string()),
+            None,
+            Some("whisper".to_string()),
+            None
+        )
+        .is_err());
+        assert!(build_azure_whisper_config(
+            Some("azure".to_string()),
+            Some("https://r.openai.azure.com".to_string()),
+            None,
+            None
+        )
+        .is_err());
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -48,7 +48,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https://api.groq.com https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com; style-src 'self' 'unsafe-inline'; script-src 'self'; media-src 'self' blob: http://asset.localhost",
+      "csp": "default-src 'self'; connect-src 'self' https://api.groq.com https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com https://*.openai.azure.com https://*.services.ai.azure.com https://*.cognitiveservices.azure.com; style-src 'self' 'unsafe-inline'; script-src 'self'; media-src 'self' blob: http://asset.localhost",
       "assetProtocol": {
         "enable": true,
         "scope": [

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -68,7 +68,8 @@
       "openai": "OpenAI (Recommended)",
       "anthropic": "Anthropic",
       "gemini": "Google Gemini (Free Quota)",
-      "groqNote": "Uses Groq API Key above"
+      "groqNote": "Uses Groq API Key above",
+      "azure": "Azure / Microsoft Foundry"
     },
     "providerApiKey": {
       "openaiTitle": "OpenAI API Key",
@@ -187,6 +188,26 @@
       "description": "Auto-detect corrections after paste and learn new terms via AI analysis",
       "privacyNote": "When enabled, the system reads text near the cursor for AI analysis. No original text is stored",
       "analysisModelUpdated": "Dictionary analysis model updated"
+    },
+    "azure": {
+      "title": "Azure / Microsoft Foundry",
+      "description": "Configure one Azure endpoint and credential shared by text enhancement and transcription.",
+      "endpointLabel": "Endpoint URL",
+      "endpointPlaceholder": "https://your-resource.openai.azure.com",
+      "apiKeyLabel": "API Key",
+      "apiVersionLabel": "API version (optional)",
+      "apiVersionPlaceholder": "Leave blank for default",
+      "clear": "Clear connection",
+      "saved": "Azure connection saved",
+      "deleted": "Azure connection cleared",
+      "deploymentSaved": "Deployment name saved",
+      "chatDeploymentLabel": "Chat deployment name",
+      "chatDeploymentPlaceholder": "e.g. gpt-4o",
+      "chatHint": "Enter the name of your chat model deployment on Azure.",
+      "notConfiguredHint": "Enable and configure the connection in the Azure / Microsoft Foundry card above first.",
+      "whisperDeploymentLabel": "Whisper deployment name",
+      "whisperDeploymentPlaceholder": "e.g. whisper",
+      "whisperHint": "Enter the name of your Whisper model deployment on Azure."
     }
   },
   "dashboard": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -36,12 +36,12 @@
       "comboKey": "コンボキー",
       "keys": {
         "fn": "Fn",
-        "leftOption": "左 Option (\u2325)",
-        "rightOption": "右 Option (\u2325)",
-        "leftControl": "左 Control (\u2303)",
-        "rightControl": "右 Control (\u2303)",
-        "command": "Command (\u2318)",
-        "shift": "Shift (\u21e7)",
+        "leftOption": "左 Option (⌥)",
+        "rightOption": "右 Option (⌥)",
+        "leftControl": "左 Control (⌃)",
+        "rightControl": "右 Control (⌃)",
+        "command": "Command (⌘)",
+        "shift": "Shift (⇧)",
         "rightAlt": "右 Alt",
         "leftAlt": "左 Alt",
         "control": "Control"
@@ -68,7 +68,8 @@
       "openai": "OpenAI（おすすめ）",
       "anthropic": "Anthropic",
       "gemini": "Google Gemini（無料枠あり）",
-      "groqNote": "上記の Groq API Key を使用"
+      "groqNote": "上記の Groq API Key を使用",
+      "azure": "Azure / Microsoft Foundry"
     },
     "providerApiKey": {
       "openaiTitle": "OpenAI API Key",
@@ -187,6 +188,26 @@
       "description": "貼り付け後に修正を自動検出し、AI 分析で新語を学習",
       "privacyNote": "有効にすると、AI 分析のためにカーソル付近のテキストを読み取ります。原文は保存されません",
       "analysisModelUpdated": "辞書分析モデルを更新しました"
+    },
+    "azure": {
+      "title": "Azure / Microsoft Foundry",
+      "description": "Azure のエンドポイントと資格情報を 1 組設定し、テキスト整形と文字起こしで共用します。",
+      "endpointLabel": "エンドポイント URL",
+      "endpointPlaceholder": "https://your-resource.openai.azure.com",
+      "apiKeyLabel": "API キー",
+      "apiVersionLabel": "API バージョン（任意）",
+      "apiVersionPlaceholder": "空欄で既定値",
+      "clear": "接続をクリア",
+      "saved": "Azure 接続を保存しました",
+      "deleted": "Azure 接続をクリアしました",
+      "deploymentSaved": "デプロイ名を保存しました",
+      "chatDeploymentLabel": "Chat デプロイ名",
+      "chatDeploymentPlaceholder": "例: gpt-4o",
+      "chatHint": "Azure 上の chat モデルのデプロイ名を入力してください。",
+      "notConfiguredHint": "先に上の「Azure / Microsoft Foundry」カードで接続を有効化・設定してください。",
+      "whisperDeploymentLabel": "Whisper デプロイ名",
+      "whisperDeploymentPlaceholder": "例: whisper",
+      "whisperHint": "Azure 上の Whisper モデルのデプロイ名を入力してください。"
     }
   },
   "dashboard": {
@@ -272,7 +293,7 @@
     "noSpeechDetected": "音声が検出されませんでした",
     "recording": "録音中...",
     "transcribing": "文字起こし中...",
-    "pasteSuccess": "貼り付け完了 \u2713",
+    "pasteSuccess": "貼り付け完了 ✓",
     "pasteSuccessUnenhanced": "貼り付け完了（未整理）",
     "enhancing": "整理中...",
     "pasteFailed": "貼り付け失敗",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -68,7 +68,8 @@
       "openai": "OpenAI (추천)",
       "anthropic": "Anthropic",
       "gemini": "Google Gemini (무료 할당량)",
-      "groqNote": "위의 Groq API Key 사용"
+      "groqNote": "위의 Groq API Key 사용",
+      "azure": "Azure / Microsoft Foundry"
     },
     "providerApiKey": {
       "openaiTitle": "OpenAI API Key",
@@ -187,6 +188,26 @@
       "description": "붙여넣기 후 수정을 자동 감지하고 AI 분석으로 새 용어 학습",
       "privacyNote": "활성화하면 AI 분석을 위해 커서 주변의 텍스트를 읽습니다. 원문은 저장되지 않습니다",
       "analysisModelUpdated": "사전 분석 모델이 업데이트되었습니다"
+    },
+    "azure": {
+      "title": "Azure / Microsoft Foundry",
+      "description": "Azure 엔드포인트와 자격 증명을 한 세트 설정하면 텍스트 정리와 음성 전사가 공유합니다.",
+      "endpointLabel": "엔드포인트 URL",
+      "endpointPlaceholder": "https://your-resource.openai.azure.com",
+      "apiKeyLabel": "API 키",
+      "apiVersionLabel": "API 버전(선택)",
+      "apiVersionPlaceholder": "비워 두면 기본값",
+      "clear": "연결 지우기",
+      "saved": "Azure 연결이 저장되었습니다",
+      "deleted": "Azure 연결이 지워졌습니다",
+      "deploymentSaved": "배포 이름이 저장되었습니다",
+      "chatDeploymentLabel": "Chat 배포 이름",
+      "chatDeploymentPlaceholder": "예: gpt-4o",
+      "chatHint": "Azure의 chat 모델 배포 이름을 입력하세요.",
+      "notConfiguredHint": "먼저 위의 'Azure / Microsoft Foundry' 카드에서 연결을 활성화하고 설정하세요.",
+      "whisperDeploymentLabel": "Whisper 배포 이름",
+      "whisperDeploymentPlaceholder": "예: whisper",
+      "whisperHint": "Azure의 Whisper 모델 배포 이름을 입력하세요."
     }
   },
   "dashboard": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -68,7 +68,8 @@
       "openai": "OpenAI（推荐）",
       "anthropic": "Anthropic",
       "gemini": "Google Gemini（免费额度）",
-      "groqNote": "使用上方 Groq API Key"
+      "groqNote": "使用上方 Groq API Key",
+      "azure": "Azure / Microsoft Foundry"
     },
     "providerApiKey": {
       "openaiTitle": "OpenAI API Key",
@@ -187,6 +188,26 @@
       "description": "转录粘贴后自动检测修正，通过 AI 分析学习新词汇",
       "privacyNote": "启用后，系统会读取光标附近的文字用于 AI 分析，不存储原文",
       "analysisModelUpdated": "字典分析模型已更新"
+    },
+    "azure": {
+      "title": "Azure / Microsoft Foundry",
+      "description": "设置一组 Azure 端点与凭证，文字整理与语音转录可共用。",
+      "endpointLabel": "端点 URL",
+      "endpointPlaceholder": "https://your-resource.openai.azure.com",
+      "apiKeyLabel": "API Key",
+      "apiVersionLabel": "API 版本（选填）",
+      "apiVersionPlaceholder": "留空使用默认值",
+      "clear": "清除连接",
+      "saved": "Azure 连接已保存",
+      "deleted": "Azure 连接已清除",
+      "deploymentSaved": "部署名称已保存",
+      "chatDeploymentLabel": "Chat 部署名称",
+      "chatDeploymentPlaceholder": "例如 gpt-4o",
+      "chatHint": "输入你在 Azure 上的 chat 模型部署名称。",
+      "notConfiguredHint": "请先在上方“Azure / Microsoft Foundry”卡片启用并设置连接。",
+      "whisperDeploymentLabel": "Whisper 部署名称",
+      "whisperDeploymentPlaceholder": "例如 whisper",
+      "whisperHint": "输入你在 Azure 上的 Whisper 模型部署名称。"
     }
   },
   "dashboard": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -68,7 +68,8 @@
       "openai": "OpenAI（推薦）",
       "anthropic": "Anthropic",
       "gemini": "Google Gemini（免費額度）",
-      "groqNote": "使用上方 Groq API Key"
+      "groqNote": "使用上方 Groq API Key",
+      "azure": "Azure / Microsoft Foundry"
     },
     "providerApiKey": {
       "openaiTitle": "OpenAI API Key",
@@ -187,6 +188,26 @@
       "description": "轉錄貼上後自動偵測修正，透過 AI 分析學習新詞彙",
       "privacyNote": "啟用後，系統會讀取游標附近的文字用於 AI 分析，不儲存原文",
       "analysisModelUpdated": "字典分析模型已更新"
+    },
+    "azure": {
+      "title": "Azure / Microsoft Foundry",
+      "description": "設定一組 Azure 端點與憑證，文字整理與語音轉錄可共用。",
+      "endpointLabel": "端點 URL",
+      "endpointPlaceholder": "https://your-resource.openai.azure.com",
+      "apiKeyLabel": "API Key",
+      "apiVersionLabel": "API 版本（選填）",
+      "apiVersionPlaceholder": "留空使用預設",
+      "clear": "清除連線",
+      "saved": "Azure 連線已儲存",
+      "deleted": "Azure 連線已清除",
+      "deploymentSaved": "部署名稱已儲存",
+      "chatDeploymentLabel": "Chat 部署名稱",
+      "chatDeploymentPlaceholder": "例如 gpt-4o",
+      "chatHint": "輸入你在 Azure 上的 chat 模型部署名稱。",
+      "notConfiguredHint": "請先在上方「Azure / Microsoft Foundry」卡啟用並設定連線。",
+      "whisperDeploymentLabel": "Whisper 部署名稱",
+      "whisperDeploymentPlaceholder": "例如 whisper",
+      "whisperHint": "輸入你在 Azure 上的 Whisper 模型部署名稱。"
     }
   },
   "dashboard": {

--- a/src/lib/connectionTest.ts
+++ b/src/lib/connectionTest.ts
@@ -1,10 +1,18 @@
 import { invoke } from "@tauri-apps/api/core";
-import { enhanceText } from "./enhancer";
-import {
-  getEnhancementErrorMessage,
-  getTranscriptionErrorMessage,
-} from "./errorUtils";
-import type { LlmModelId, WhisperModelId } from "./modelRegistry";
+import { enhanceText, EnhancerApiError } from "./enhancer";
+import type { LlmProviderId, WhisperModelId } from "./modelRegistry";
+import type { AzureRequestOptions } from "./llmProvider";
+
+function formatConnectionError(err: unknown): string {
+  if (err instanceof EnhancerApiError) {
+    const body = err.body?.trim();
+    return body
+      ? `API error ${err.statusCode}: ${body.slice(0, 400)}`
+      : `API error ${err.statusCode}`;
+  }
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
 
 export interface TestSuccess {
   ok: true;
@@ -20,13 +28,16 @@ export interface TestFailure {
 export type TestResult = TestSuccess | TestFailure;
 
 export async function testLlmConnection(
-  modelId: LlmModelId,
+  modelId: string,
   apiKey: string,
+  extras?: { provider?: LlmProviderId; azure?: AzureRequestOptions },
 ): Promise<TestResult> {
   const start = performance.now();
   try {
     await enhanceText("ping", apiKey, {
       modelId,
+      provider: extras?.provider,
+      azure: extras?.azure,
       systemPrompt: "Reply with the word OK only.",
       maxTokens: 50,
     });
@@ -35,7 +46,7 @@ export async function testLlmConnection(
     return {
       ok: false,
       durationMs: elapsed(start),
-      errorMessage: getEnhancementErrorMessage(err),
+      errorMessage: formatConnectionError(err),
     };
   }
 }
@@ -43,16 +54,29 @@ export async function testLlmConnection(
 export async function testWhisperConnection(
   modelId: WhisperModelId,
   apiKey: string,
+  extras?: {
+    provider?: "groq" | "azure";
+    endpoint?: string;
+    deployment?: string;
+    apiVersion?: string;
+  },
 ): Promise<TestResult> {
   const start = performance.now();
   try {
-    await invoke("test_whisper_connection", { apiKey, modelId });
+    await invoke("test_whisper_connection", {
+      apiKey,
+      modelId,
+      provider: extras?.provider,
+      endpoint: extras?.endpoint ?? null,
+      deployment: extras?.deployment ?? null,
+      apiVersion: extras?.apiVersion ?? null,
+    });
     return { ok: true, durationMs: elapsed(start) };
   } catch (err) {
     return {
       ok: false,
       durationMs: elapsed(start),
-      errorMessage: getTranscriptionErrorMessage(err),
+      errorMessage: formatConnectionError(err),
     };
   }
 }

--- a/src/lib/enhancer.ts
+++ b/src/lib/enhancer.ts
@@ -1,6 +1,6 @@
 import { fetch } from "@tauri-apps/plugin-http";
 import type { ChatUsageData, EnhanceResult } from "../types/transcription";
-import { DEFAULT_LLM_MODEL_ID } from "./modelRegistry";
+import { DEFAULT_LLM_MODEL_ID, type LlmProviderId } from "./modelRegistry";
 import {
   buildFetchParams,
   parseProviderResponse,
@@ -8,6 +8,7 @@ import {
   getProviderTimeout,
   getDefaultMaxTokens,
   type LlmChatRequest,
+  type AzureRequestOptions,
 } from "./llmProvider";
 import { getMinimalPromptForLocale } from "../i18n/prompts";
 import type { SupportedLocale } from "../i18n/languageConfig";
@@ -36,6 +37,9 @@ export interface EnhanceOptions {
   modelId?: string;
   signal?: AbortSignal;
   maxTokens?: number;
+  // azure 時由呼叫端明確指定 provider 與連線設定（不經 model 反查）
+  provider?: LlmProviderId;
+  azure?: AzureRequestOptions;
 }
 
 async function withTimeout<T>(
@@ -110,7 +114,7 @@ export async function enhanceText(
   }
 
   const modelId = options?.modelId ?? DEFAULT_LLM_MODEL_ID;
-  const providerId = getProviderIdForModel(modelId);
+  const providerId = options?.provider ?? getProviderIdForModel(modelId);
 
   const basePrompt = options?.systemPrompt || getDefaultSystemPrompt();
   const fullPrompt = buildSystemPrompt(basePrompt, options?.vocabularyTermList);
@@ -125,7 +129,12 @@ export async function enhanceText(
     maxTokens: options?.maxTokens ?? getDefaultMaxTokens(providerId),
   };
 
-  const { url, init } = buildFetchParams(providerId, request, apiKey);
+  const { url, init } = buildFetchParams(
+    providerId,
+    request,
+    apiKey,
+    options?.azure,
+  );
 
   const response = await withTimeout(
     fetch(url, {

--- a/src/lib/errorUtils.ts
+++ b/src/lib/errorUtils.ts
@@ -43,37 +43,37 @@ const NETWORK_ERROR_PATTERN =
   /network|connect|dns|resolve|offline|timed?\s*out|ECONNREFUSED|ENOTFOUND|os error/i;
 
 export function getTranscriptionErrorMessage(error: unknown): string {
-  if (error instanceof TypeError) {
+  if (typeof error === "string" && NETWORK_ERROR_PATTERN.test(error)) {
     return t("errors.network");
   }
 
-  if (error instanceof Error) {
-    if (
-      !error.message.includes("Groq API error") &&
-      NETWORK_ERROR_PATTERN.test(error.message)
-    ) {
-      return t("errors.network");
-    }
+  const message = extractErrorMessage(error);
 
-    if (error.message.includes("Audio file too large")) {
-      return t("errors.transcription.fileTooLarge");
-    }
+  if (
+    !message.includes("Transcription API error") &&
+    NETWORK_ERROR_PATTERN.test(message)
+  ) {
+    return t("errors.network");
+  }
 
-    if (error.message.includes("Groq API error")) {
-      const statusMatch = error.message.match(/\((\d+)\)/);
-      if (statusMatch) {
-        const status = parseInt(statusMatch[1], 10);
-        if (status === 400) return t("errors.transcription.invalidAudio");
-        if (status === 401) return t("errors.transcription.invalidApiKey");
-        if (status === 429) return t("errors.transcription.rateLimited");
-        if (status >= 500) return t("errors.transcription.serviceUnavailable");
-      }
-      return t("errors.transcription.failed");
-    }
+  if (message.includes("Audio file too large")) {
+    return t("errors.transcription.fileTooLarge");
+  }
 
-    if (error.message.includes("MediaRecorder")) {
-      return t("errors.transcription.recorderError");
+  if (message.includes("Transcription API error")) {
+    const statusMatch = message.match(/\((\d+)\)/);
+    if (statusMatch) {
+      const status = parseInt(statusMatch[1], 10);
+      if (status === 400) return t("errors.transcription.invalidAudio");
+      if (status === 401) return t("errors.transcription.invalidApiKey");
+      if (status === 429) return t("errors.transcription.rateLimited");
+      if (status >= 500) return t("errors.transcription.serviceUnavailable");
     }
+    return t("errors.transcription.failed");
+  }
+
+  if (message.includes("MediaRecorder")) {
+    return t("errors.transcription.recorderError");
   }
 
   return t("errors.transcription.operationFailed");

--- a/src/lib/llmProvider.ts
+++ b/src/lib/llmProvider.ts
@@ -40,6 +40,14 @@ export const LLM_PROVIDER_LIST: LlmProviderConfig[] = [
     consoleUrl: "https://console.anthropic.com/settings/keys",
     apiKeyPrefix: "sk-ant-",
   },
+  {
+    id: "azure",
+    displayName: "Azure / Microsoft Foundry",
+    // baseUrl 為動態（使用者自訂 endpoint），實際組裝於 buildAzureFetchParams
+    baseUrl: "",
+    consoleUrl: "https://ai.azure.com/",
+    apiKeyPrefix: "",
+  },
 ];
 
 export function findProviderConfig(
@@ -55,6 +63,7 @@ const PROVIDER_TIMEOUT_MS: Record<LlmProviderId, number> = {
   openai: 30_000,
   anthropic: 30_000,
   gemini: 30_000,
+  azure: 30_000,
 };
 
 export function getProviderTimeout(providerId: LlmProviderId): number {
@@ -69,6 +78,7 @@ const PROVIDER_DEFAULT_MAX_TOKENS: Record<LlmProviderId, number> = {
   openai: 16384,
   anthropic: 8192,
   gemini: 16384,
+  azure: 16384,
 };
 
 export function getDefaultMaxTokens(providerId: LlmProviderId): number {
@@ -109,11 +119,25 @@ export function getProviderIdForModel(modelId: string): LlmProviderId {
   return findLlmModelConfig(modelId)?.providerId ?? "groq";
 }
 
+export interface AzureRequestOptions {
+  endpoint: string;
+  apiVersion?: string;
+  apiKey: string;
+}
+
 export function buildFetchParams(
   providerId: LlmProviderId,
   request: LlmChatRequest,
   apiKey: string,
+  azureOptions?: AzureRequestOptions,
 ): { url: string; init: RequestInit } {
+  if (providerId === "azure") {
+    if (!azureOptions) {
+      throw new Error("Azure provider requires azureOptions");
+    }
+    return buildAzureFetchParams(request, azureOptions);
+  }
+
   const providerConfig = findProviderConfig(providerId);
   const url = providerConfig?.baseUrl ?? LLM_PROVIDER_LIST[0].baseUrl;
 
@@ -126,6 +150,52 @@ export function buildFetchParams(
   }
 
   return buildOpenAiCompatibleFetchParams(providerId, url, request, apiKey);
+}
+
+/** 把使用者貼上的 Azure endpoint 正規化成 resource base（只留 protocol+host，丟掉 path/query/hash）。 */
+export function normalizeAzureEndpoint(endpoint: string): string {
+  const trimmed = endpoint.trim();
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    // 缺 scheme 等不完整輸入 → 字串退場：去 path/query/hash 與尾斜線
+    return trimmed.replace(/[/?#].*$/, "").replace(/\/+$/, "");
+  }
+}
+
+function buildAzureFetchParams(
+  request: LlmChatRequest,
+  opts: AzureRequestOptions,
+): { url: string; init: RequestInit } {
+  const base = normalizeAzureEndpoint(opts.endpoint);
+  const query = opts.apiVersion
+    ? `?api-version=${encodeURIComponent(opts.apiVersion)}`
+    : "";
+  const url = `${base}/openai/v1/chat/completions${query}`;
+
+  const body: Record<string, unknown> = {
+    model: request.model, // Azure 的 model = 部署名稱
+    messages: request.messages,
+  };
+  if (request.temperature !== undefined) body.temperature = request.temperature;
+  if (request.maxTokens !== undefined) {
+    // v1 / GPT-5 系列要求 max_completion_tokens
+    body.max_completion_tokens = request.maxTokens;
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "api-key": opts.apiKey,
+  };
+
+  return {
+    url,
+    init: {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    },
+  };
 }
 
 function buildOpenAiCompatibleFetchParams(

--- a/src/lib/modelRegistry.ts
+++ b/src/lib/modelRegistry.ts
@@ -1,6 +1,6 @@
 // ── LLM Provider ──────────────────────────────────────────
 
-export type LlmProviderId = "groq" | "openai" | "anthropic" | "gemini";
+export type LlmProviderId = "groq" | "openai" | "anthropic" | "gemini" | "azure";
 
 export const DEFAULT_LLM_PROVIDER_ID: LlmProviderId = "groq";
 

--- a/src/lib/vocabularyAnalyzer.ts
+++ b/src/lib/vocabularyAnalyzer.ts
@@ -1,5 +1,5 @@
 import { fetch } from "@tauri-apps/plugin-http";
-import { DEFAULT_LLM_MODEL_ID } from "./modelRegistry";
+import { DEFAULT_LLM_MODEL_ID, type LlmProviderId } from "./modelRegistry";
 import {
   buildFetchParams,
   parseProviderResponse,
@@ -7,6 +7,7 @@ import {
   getProviderTimeout,
   type LlmChatRequest,
   type LlmUsageData,
+  type AzureRequestOptions,
 } from "./llmProvider";
 
 const SYSTEM_PROMPT = `你是語音轉錄字典助手。
@@ -105,10 +106,14 @@ export async function analyzeCorrections(
   pastedText: string,
   fieldText: string,
   apiKey: string,
-  options?: { modelId?: string },
+  options?: {
+    modelId?: string;
+    provider?: LlmProviderId;
+    azure?: AzureRequestOptions;
+  },
 ): Promise<VocabularyAnalysisResult> {
   const modelId = options?.modelId ?? DEFAULT_LLM_MODEL_ID;
-  const providerId = getProviderIdForModel(modelId);
+  const providerId = options?.provider ?? getProviderIdForModel(modelId);
 
   const request: LlmChatRequest = {
     model: modelId,
@@ -123,7 +128,12 @@ export async function analyzeCorrections(
     maxTokens: 256,
   };
 
-  const { url, init } = buildFetchParams(providerId, request, apiKey);
+  const { url, init } = buildFetchParams(
+    providerId,
+    request,
+    apiKey,
+    options?.azure,
+  );
 
   const timeoutMs = getProviderTimeout(providerId);
   const controller = new AbortController();

--- a/src/stores/useSettingsStore.ts
+++ b/src/stores/useSettingsStore.ts
@@ -58,6 +58,10 @@ import {
   type LlmProviderId,
   type WhisperModelId,
 } from "../lib/modelRegistry";
+import {
+  normalizeAzureEndpoint,
+  type AzureRequestOptions,
+} from "../lib/llmProvider";
 
 declare const __APP_VERSION__: string;
 
@@ -123,6 +127,13 @@ export const useSettingsStore = defineStore("settings", () => {
         return anthropicApiKey.value !== "";
       case "gemini":
         return geminiApiKey.value !== "";
+      case "azure":
+        return (
+          azureEnabled.value &&
+          azureEndpoint.value !== "" &&
+          azureChatDeployment.value !== "" &&
+          azureApiKey.value !== ""
+        );
       default:
         // exhaustiveness：若 LlmProviderId 新增成員，這行會 type error
         selectedLlmProviderId.value satisfies never;
@@ -148,6 +159,23 @@ export const useSettingsStore = defineStore("settings", () => {
   const isCopyTranscriptionToClipboardEnabled = ref<boolean>(
     DEFAULT_COPY_TRANSCRIPTION_TO_CLIPBOARD,
   );
+  // ── Azure / Microsoft Foundry ──
+  const azureEnabled = ref<boolean>(false);
+  const azureEndpoint = ref<string>("");
+  const azureApiKey = ref<string>("");
+  const azureApiVersion = ref<string>("");
+  const azureChatDeployment = ref<string>("");
+  const azureWhisperDeployment = ref<string>("");
+  const whisperProviderId = ref<"groq" | "azure">("groq");
+  const hasWhisperConfig = computed(() => {
+    if (whisperProviderId.value !== "azure") return apiKey.value !== "";
+    return (
+      azureEnabled.value &&
+      azureEndpoint.value !== "" &&
+      azureWhisperDeployment.value !== "" &&
+      azureApiKey.value !== ""
+    );
+  });
   let isLoaded = false;
 
   /** Resolve which SupportedLocale to use for prompt default (shared logic). */
@@ -171,7 +199,84 @@ export const useSettingsStore = defineStore("settings", () => {
         return anthropicApiKey.value;
       case "gemini":
         return geminiApiKey.value;
+      case "azure":
+        return azureApiKey.value;
     }
+  }
+
+  function getAzureRequestOptions(): AzureRequestOptions {
+    return {
+      endpoint: azureEndpoint.value,
+      apiVersion: azureApiVersion.value || undefined,
+      apiKey: azureApiKey.value,
+    };
+  }
+
+  async function getLlmRequestConfig(): Promise<{
+    apiKey: string;
+    provider: LlmProviderId;
+    modelId: string;
+    azure?: AzureRequestOptions;
+  }> {
+    const provider = selectedLlmProviderId.value;
+    if (provider !== "azure") {
+      return {
+        apiKey: getLlmApiKey(),
+        provider,
+        modelId: selectedLlmModelId.value,
+      };
+    }
+
+    if (
+      !azureEnabled.value ||
+      azureEndpoint.value === "" ||
+      azureChatDeployment.value === ""
+    ) {
+      return { apiKey: "", provider, modelId: azureChatDeployment.value };
+    }
+
+    return {
+      apiKey: azureApiKey.value,
+      provider,
+      modelId: azureChatDeployment.value,
+      azure: getAzureRequestOptions(),
+    };
+  }
+
+  /** 用於 usage 記錄/成本計算的有效 chat 模型：Azure 用部署名，其餘用 selectedLlmModelId。 */
+  function getEffectiveChatModel(): string {
+    return selectedLlmProviderId.value === "azure"
+      ? azureChatDeployment.value
+      : selectedLlmModelId.value;
+  }
+
+  async function getWhisperRequestConfig(): Promise<{
+    apiKey: string;
+    provider: "groq" | "azure";
+    endpoint?: string;
+    deployment?: string;
+    apiVersion?: string;
+  }> {
+    if (whisperProviderId.value !== "azure") {
+      return { apiKey: apiKey.value, provider: "groq" };
+    }
+
+    if (
+      !azureEnabled.value ||
+      azureEndpoint.value === "" ||
+      azureWhisperDeployment.value === ""
+    ) {
+      return { apiKey: "", provider: "azure" };
+    }
+
+    const base = {
+      provider: "azure" as const,
+      endpoint: azureEndpoint.value,
+      deployment: azureWhisperDeployment.value,
+      apiVersion: azureApiVersion.value || undefined,
+    };
+
+    return { ...base, apiKey: azureApiKey.value };
   }
 
   async function syncHotkeyConfigToRust(key: TriggerKey, mode: TriggerMode) {
@@ -299,6 +404,20 @@ export const useSettingsStore = defineStore("settings", () => {
       const savedGeminiApiKey = await store.get<string>("geminiApiKey");
       geminiApiKey.value = savedGeminiApiKey?.trim() ?? "";
 
+      // Azure / Microsoft Foundry
+      azureEnabled.value = (await store.get<boolean>("azureEnabled")) ?? false;
+      azureEndpoint.value =
+        (await store.get<string>("azureEndpoint"))?.trim() ?? "";
+      azureApiKey.value = (await store.get<string>("azureApiKey"))?.trim() ?? "";
+      azureApiVersion.value =
+        (await store.get<string>("azureApiVersion"))?.trim() ?? "";
+      azureChatDeployment.value =
+        (await store.get<string>("azureChatDeployment"))?.trim() ?? "";
+      azureWhisperDeployment.value =
+        (await store.get<string>("azureWhisperDeployment"))?.trim() ?? "";
+      whisperProviderId.value =
+        (await store.get<"groq" | "azure">("whisperProviderId")) ?? "groq";
+
       // LLM Model ID（含 Kimi K2 遷移）
       const savedLlmModelId = await store.get<string>("llmModelId");
       const llmMigratedFromKimiK2 = await store.get<boolean>(
@@ -323,7 +442,11 @@ export const useSettingsStore = defineStore("settings", () => {
 
       // model-provider 交叉驗證：防止 key 洩漏到錯誤 provider
       const modelConfig = findLlmModelConfig(selectedLlmModelId.value);
-      if (modelConfig && modelConfig.providerId !== selectedLlmProviderId.value) {
+      if (
+        selectedLlmProviderId.value !== "azure" &&
+        modelConfig &&
+        modelConfig.providerId !== selectedLlmProviderId.value
+      ) {
         selectedLlmModelId.value = getDefaultModelIdForProvider(
           selectedLlmProviderId.value,
         );
@@ -764,22 +887,22 @@ export const useSettingsStore = defineStore("settings", () => {
       const store = await load(STORE_NAME);
       await store.set("llmProviderId", providerId);
 
-      // 切換 provider 時重設為該 provider 預設模型
-      const defaultModelId = getDefaultModelIdForProvider(providerId);
-      await store.set("llmModelId", defaultModelId);
+      // 切換 provider 時重設為該 provider 預設模型；Azure 例外（模型 = 部署名稱）
+      if (providerId !== "azure") {
+        const defaultModelId = getDefaultModelIdForProvider(providerId);
+        await store.set("llmModelId", defaultModelId);
+        selectedLlmModelId.value = defaultModelId;
+      }
       await store.save();
 
       selectedLlmProviderId.value = providerId;
-      selectedLlmModelId.value = defaultModelId;
 
       const payload: SettingsUpdatedPayload = {
         key: "llmProvider",
         value: providerId,
       };
       await emitEvent(SETTINGS_UPDATED, payload);
-      console.log(
-        `[useSettingsStore] LLM provider saved: ${providerId}, model reset to: ${defaultModelId}`,
-      );
+      console.log(`[useSettingsStore] LLM provider saved: ${providerId}`);
     } catch (err) {
       console.error(
         "[useSettingsStore] saveLlmProvider failed:",
@@ -907,6 +1030,164 @@ export const useSettingsStore = defineStore("settings", () => {
     }
   }
 
+  async function saveAzureConnection(cfg: {
+    enabled: boolean;
+    endpoint: string;
+    apiKey: string;
+    apiVersion: string;
+  }) {
+    try {
+      const store = await load(STORE_NAME);
+      const normalizedEndpoint = normalizeAzureEndpoint(cfg.endpoint);
+      await store.set("azureEnabled", cfg.enabled);
+      await store.set("azureEndpoint", normalizedEndpoint);
+      await store.set("azureApiKey", cfg.apiKey.trim());
+      await store.set("azureApiVersion", cfg.apiVersion.trim());
+
+      // 停用 Azure 時，把仍指向 azure 的 provider 切回 groq（避免無 UI 可切換而卡死）
+      if (!cfg.enabled) {
+        if (selectedLlmProviderId.value === "azure") {
+          const groqModel = getDefaultModelIdForProvider("groq");
+          await store.set("llmProviderId", "groq");
+          await store.set("llmModelId", groqModel);
+          selectedLlmProviderId.value = "groq";
+          selectedLlmModelId.value = groqModel;
+        }
+        if (whisperProviderId.value === "azure") {
+          await store.set("whisperProviderId", "groq");
+          whisperProviderId.value = "groq";
+        }
+      }
+      await store.save();
+
+      azureEnabled.value = cfg.enabled;
+      azureEndpoint.value = normalizedEndpoint;
+      azureApiKey.value = cfg.apiKey.trim();
+      azureApiVersion.value = cfg.apiVersion.trim();
+
+      const payload: SettingsUpdatedPayload = {
+        key: "azureConnection",
+        value: cfg.enabled,
+      };
+      await emitEvent(SETTINGS_UPDATED, payload);
+      console.log("[useSettingsStore] Azure connection saved");
+    } catch (err) {
+      console.error(
+        "[useSettingsStore] saveAzureConnection failed:",
+        extractErrorMessage(err),
+      );
+      captureError(err, { source: "settings", step: "save-azure-connection" });
+      throw err;
+    }
+  }
+
+  async function deleteAzureConnection() {
+    try {
+      const store = await load(STORE_NAME);
+      const keys = [
+        "azureEnabled",
+        "azureEndpoint",
+        "azureApiKey",
+        "azureApiVersion",
+      ];
+      for (const k of keys) {
+        await store.delete(k);
+      }
+
+      // 把仍指向 azure 的 provider 切回 groq，否則轉錄/整理會卡在「未設定」
+      if (selectedLlmProviderId.value === "azure") {
+        const groqModel = getDefaultModelIdForProvider("groq");
+        await store.set("llmProviderId", "groq");
+        await store.set("llmModelId", groqModel);
+        selectedLlmProviderId.value = "groq";
+        selectedLlmModelId.value = groqModel;
+      }
+      if (whisperProviderId.value === "azure") {
+        await store.set("whisperProviderId", "groq");
+        whisperProviderId.value = "groq";
+      }
+      await store.save();
+
+      azureEnabled.value = false;
+      azureEndpoint.value = "";
+      azureApiKey.value = "";
+      azureApiVersion.value = "";
+
+      const payload: SettingsUpdatedPayload = {
+        key: "azureConnection",
+        value: false,
+      };
+      await emitEvent(SETTINGS_UPDATED, payload);
+      console.log("[useSettingsStore] Azure connection deleted");
+    } catch (err) {
+      console.error(
+        "[useSettingsStore] deleteAzureConnection failed:",
+        extractErrorMessage(err),
+      );
+      throw err;
+    }
+  }
+
+  async function saveAzureChatDeployment(name: string) {
+    try {
+      const store = await load(STORE_NAME);
+      await store.set("azureChatDeployment", name.trim());
+      await store.save();
+      azureChatDeployment.value = name.trim();
+      const payload: SettingsUpdatedPayload = {
+        key: "azureChatDeployment",
+        value: name.trim(),
+      };
+      await emitEvent(SETTINGS_UPDATED, payload);
+    } catch (err) {
+      console.error(
+        "[useSettingsStore] saveAzureChatDeployment failed:",
+        extractErrorMessage(err),
+      );
+      throw err;
+    }
+  }
+
+  async function saveAzureWhisperDeployment(name: string) {
+    try {
+      const store = await load(STORE_NAME);
+      await store.set("azureWhisperDeployment", name.trim());
+      await store.save();
+      azureWhisperDeployment.value = name.trim();
+      const payload: SettingsUpdatedPayload = {
+        key: "azureWhisperDeployment",
+        value: name.trim(),
+      };
+      await emitEvent(SETTINGS_UPDATED, payload);
+    } catch (err) {
+      console.error(
+        "[useSettingsStore] saveAzureWhisperDeployment failed:",
+        extractErrorMessage(err),
+      );
+      throw err;
+    }
+  }
+
+  async function saveWhisperProvider(id: "groq" | "azure") {
+    try {
+      const store = await load(STORE_NAME);
+      await store.set("whisperProviderId", id);
+      await store.save();
+      whisperProviderId.value = id;
+      const payload: SettingsUpdatedPayload = {
+        key: "whisperProvider",
+        value: id,
+      };
+      await emitEvent(SETTINGS_UPDATED, payload);
+    } catch (err) {
+      console.error(
+        "[useSettingsStore] saveWhisperProvider failed:",
+        extractErrorMessage(err),
+      );
+      throw err;
+    }
+  }
+
   async function refreshLlmApiKey() {
     try {
       const store = await load(STORE_NAME);
@@ -929,6 +1210,17 @@ export const useSettingsStore = defineStore("settings", () => {
         case "gemini": {
           const savedKey = await store.get<string>("geminiApiKey");
           geminiApiKey.value = savedKey?.trim() ?? "";
+          break;
+        }
+        case "azure": {
+          azureEndpoint.value =
+            (await store.get<string>("azureEndpoint"))?.trim() ?? "";
+          azureApiKey.value =
+            (await store.get<string>("azureApiKey"))?.trim() ?? "";
+          azureApiVersion.value =
+            (await store.get<string>("azureApiVersion"))?.trim() ?? "";
+          azureChatDeployment.value =
+            (await store.get<string>("azureChatDeployment"))?.trim() ?? "";
           break;
         }
       }
@@ -1336,6 +1628,20 @@ export const useSettingsStore = defineStore("settings", () => {
       isCopyTranscriptionToClipboardEnabled.value =
         savedCopyTranscriptionToClipboard ??
         DEFAULT_COPY_TRANSCRIPTION_TO_CLIPBOARD;
+
+      // Azure / Microsoft Foundry（跨視窗同步）
+      azureEnabled.value = (await store.get<boolean>("azureEnabled")) ?? false;
+      azureEndpoint.value =
+        (await store.get<string>("azureEndpoint"))?.trim() ?? "";
+      azureApiKey.value = (await store.get<string>("azureApiKey"))?.trim() ?? "";
+      azureApiVersion.value =
+        (await store.get<string>("azureApiVersion"))?.trim() ?? "";
+      azureChatDeployment.value =
+        (await store.get<string>("azureChatDeployment"))?.trim() ?? "";
+      azureWhisperDeployment.value =
+        (await store.get<string>("azureWhisperDeployment"))?.trim() ?? "";
+      whisperProviderId.value =
+        (await store.get<"groq" | "azure">("whisperProviderId")) ?? "groq";
     } catch (err) {
       console.error(
         "[useSettingsStore] refreshCrossWindowSettings failed:",
@@ -1387,6 +1693,10 @@ export const useSettingsStore = defineStore("settings", () => {
     geminiApiKey: computed(() => geminiApiKey.value),
     getApiKey,
     getLlmApiKey,
+    getLlmRequestConfig,
+    getWhisperRequestConfig,
+    getEffectiveChatModel,
+    hasWhisperConfig,
     getAiPrompt,
     savePromptMode,
     consumeUpgradeNotice,
@@ -1422,6 +1732,18 @@ export const useSettingsStore = defineStore("settings", () => {
     deleteAnthropicApiKey,
     saveGeminiApiKey,
     deleteGeminiApiKey,
+    azureEnabled,
+    azureEndpoint,
+    azureApiKey: computed(() => azureApiKey.value),
+    azureApiVersion,
+    azureChatDeployment,
+    azureWhisperDeployment,
+    whisperProviderId,
+    saveAzureConnection,
+    deleteAzureConnection,
+    saveAzureChatDeployment,
+    saveAzureWhisperDeployment,
+    saveWhisperProvider,
     refreshLlmApiKey,
     saveWhisperModel,
     isMuteOnRecordingEnabled,

--- a/src/stores/useVoiceFlowStore.ts
+++ b/src/stores/useVoiceFlowStore.ts
@@ -500,12 +500,12 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
   function startCorrectionDetectionFlow(
     pastedText: string,
     transcriptionId: string,
-    apiKey: string,
   ) {
     void (async () => {
       try {
         const settingsStore = useSettingsStore();
         if (!settingsStore.isSmartDictionaryEnabled) return;
+        if (!settingsStore.hasLlmApiKey) return;
 
         // 清除前一次的 listener，避免重複累積
         cleanupCorrectionMonitorListener();
@@ -613,12 +613,15 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
                     `[correction] text modified (overlap=${Math.round(overlapRatio * 100)}%) — sending to AI analysis\n  original:  ${pastedText.slice(0, 80)}\n  corrected: ${fieldText.slice(0, 80)}`,
                   );
 
+                  const llmCfg = await settingsStore.getLlmRequestConfig();
                   const analysisResult = await analyzeCorrections(
                     pastedText,
                     fieldText,
-                    apiKey,
+                    llmCfg.apiKey,
                     {
-                      modelId: settingsStore.selectedLlmModelId,
+                      modelId: llmCfg.modelId,
+                      provider: llmCfg.provider,
+                      azure: llmCfg.azure,
                     },
                   );
 
@@ -665,7 +668,7 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
                         id: crypto.randomUUID(),
                         transcriptionId,
                         apiType: "vocabulary_analysis",
-                        model: settingsStore.selectedLlmModelId,
+                        model: settingsStore.getEffectiveChatModel(),
                         promptTokens: analysisResult.usage.promptTokens,
                         completionTokens: analysisResult.usage.completionTokens,
                         totalTokens: analysisResult.usage.totalTokens,
@@ -675,7 +678,7 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
                         audioDurationMs: null,
                         estimatedCostCeiling: calculateChatCostCeiling(
                           analysisResult.usage.totalTokens,
-                          settingsStore.selectedLlmModelId,
+                          settingsStore.getEffectiveChatModel(),
                         ),
                       })
                       .catch((err) =>
@@ -773,11 +776,8 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
       const finalText = params.record.processedText ?? params.record.rawText;
       updateVocabularyWeightsAfterPaste(finalText);
 
-      // 修正偵測（fire-and-forget，需 LLM API key）
-      const llmApiKey = settingsStore.getLlmApiKey();
-      if (llmApiKey) {
-        startCorrectionDetectionFlow(params.text, params.record.id, llmApiKey);
-      }
+      // 修正偵測（fire-and-forget；API key / 設定檢查移至 flow 內部）
+      startCorrectionDetectionFlow(params.text, params.record.id);
     } catch (pasteError) {
       isRecording.value = false;
       failRecordingFlow(
@@ -829,7 +829,7 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
         id: crypto.randomUUID(),
         transcriptionId: record.id,
         apiType: "chat",
-        model: settingsStore.selectedLlmModelId,
+        model: settingsStore.getEffectiveChatModel(),
         promptTokens: chatUsage.promptTokens,
         completionTokens: chatUsage.completionTokens,
         totalTokens: chatUsage.totalTokens,
@@ -839,7 +839,7 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
         audioDurationMs: null,
         estimatedCostCeiling: calculateChatCostCeiling(
           chatUsage.totalTokens,
-          settingsStore.selectedLlmModelId,
+          settingsStore.getEffectiveChatModel(),
         ),
       });
     }
@@ -1116,14 +1116,15 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
 
       transitionTo("transcribing", t("voiceFlow.transcribing"));
       const settingsStore = useSettingsStore();
-      let apiKey = settingsStore.getApiKey();
-
-      if (!apiKey) {
+      if (
+        settingsStore.whisperProviderId === "groq" &&
+        !settingsStore.getApiKey()
+      ) {
         await settingsStore.refreshApiKey();
-        apiKey = settingsStore.getApiKey();
       }
 
-      if (!apiKey) {
+      const whisperCfg = await settingsStore.getWhisperRequestConfig();
+      if (!whisperCfg.apiKey) {
         failRecordingFlow(
           t("errors.apiKeyMissing"),
           "useVoiceFlowStore: missing API key while transcribing",
@@ -1136,10 +1137,14 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
       const hasVocabulary = whisperTermList.length > 0;
 
       const result = await invoke<TranscriptionResult>("transcribe_audio", {
-        apiKey,
+        apiKey: whisperCfg.apiKey,
         vocabularyTermList: hasVocabulary ? whisperTermList : null,
         modelId: settingsStore.selectedWhisperModelId,
         language: settingsStore.getWhisperLanguageCode(),
+        provider: whisperCfg.provider,
+        endpoint: whisperCfg.endpoint ?? null,
+        deployment: whisperCfg.deployment ?? null,
+        apiVersion: whisperCfg.apiVersion ?? null,
       });
       if (isAborted.value) return;
 
@@ -1246,8 +1251,8 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
 
         try {
           await settingsStore.refreshLlmApiKey();
-          const llmApiKey = settingsStore.getLlmApiKey();
-          if (!llmApiKey) {
+          const llmCfg = await settingsStore.getLlmRequestConfig();
+          if (!llmCfg.apiKey) {
             throw new Error(t("errors.apiKeyMissing"));
           }
 
@@ -1257,13 +1262,15 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
             systemPrompt: settingsStore.getAiPrompt(),
             vocabularyTermList:
               enhancementTermList.length > 0 ? enhancementTermList : undefined,
-            modelId: settingsStore.selectedLlmModelId,
+            modelId: llmCfg.modelId,
+            provider: llmCfg.provider,
+            azure: llmCfg.azure,
             signal: abortController?.signal,
           };
 
           let enhanceResult = await enhanceText(
             result.rawText,
-            llmApiKey,
+            llmCfg.apiKey,
             enhanceOptions,
           );
           if (isAborted.value) return;
@@ -1283,7 +1290,7 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
             );
             enhanceResult = await enhanceText(
               result.rawText,
-              llmApiKey,
+              llmCfg.apiKey,
               enhanceOptions,
             );
             if (isAborted.value) return;
@@ -1439,8 +1446,8 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
     try {
       const settingsStore = useSettingsStore();
       await settingsStore.refreshLlmApiKey();
-      const llmApiKey = settingsStore.getLlmApiKey();
-      if (!llmApiKey) {
+      const llmCfg = await settingsStore.getLlmRequestConfig();
+      if (!llmCfg.apiKey) {
         throw new Error(t("errors.apiKeyMissing"));
       }
 
@@ -1450,9 +1457,11 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
         `${basePrompt}\n\n<instruction>\n${params.voiceInstruction}\n</instruction>`,
       );
 
-      const editResult = await enhanceText(params.selectedText, llmApiKey, {
+      const editResult = await enhanceText(params.selectedText, llmCfg.apiKey, {
         systemPrompt,
-        modelId: settingsStore.selectedLlmModelId,
+        modelId: llmCfg.modelId,
+        provider: llmCfg.provider,
+        azure: llmCfg.azure,
         signal: abortController?.signal,
         maxTokens: EDIT_MODE_MAX_TOKENS,
       });
@@ -1521,14 +1530,15 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
 
     try {
       const settingsStore = useSettingsStore();
-      let apiKey = settingsStore.getApiKey();
-
-      if (!apiKey) {
+      if (
+        settingsStore.whisperProviderId === "groq" &&
+        !settingsStore.getApiKey()
+      ) {
         await settingsStore.refreshApiKey();
-        apiKey = settingsStore.getApiKey();
       }
 
-      if (!apiKey) {
+      const whisperCfg = await settingsStore.getWhisperRequestConfig();
+      if (!whisperCfg.apiKey) {
         transitionTo("error", t("errors.apiKeyMissing"));
         playSoundIfEnabled("play_error_sound");
         lastFailedAudioFilePath.value = null;
@@ -1544,11 +1554,15 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
         "retranscribe_from_file",
         {
           filePath,
-          apiKey,
+          apiKey: whisperCfg.apiKey,
           vocabularyTermList: hasVocabulary ? whisperTermList : null,
           modelId: settingsStore.selectedWhisperModelId,
           language: settingsStore.getWhisperLanguageCode(),
-        },
+          provider: whisperCfg.provider,
+          endpoint: whisperCfg.endpoint ?? null,
+          deployment: whisperCfg.deployment ?? null,
+          apiVersion: whisperCfg.apiVersion ?? null,
+          },
       );
       if (isAborted.value) return;
 
@@ -1593,18 +1607,20 @@ export const useVoiceFlowStore = defineStore("voice-flow", () => {
 
         try {
           await settingsStore.refreshLlmApiKey();
-          const llmApiKey = settingsStore.getLlmApiKey();
-          if (!llmApiKey) {
+          const llmCfg = await settingsStore.getLlmRequestConfig();
+          if (!llmCfg.apiKey) {
             throw new Error(t("errors.apiKeyMissing"));
           }
 
           const enhancementTermList =
             await vocabularyStore.getTopTermListByWeight(50);
-          const enhanceResult = await enhanceText(result.rawText, llmApiKey, {
+          const enhanceResult = await enhanceText(result.rawText, llmCfg.apiKey, {
             systemPrompt: settingsStore.getAiPrompt(),
             vocabularyTermList:
               enhancementTermList.length > 0 ? enhancementTermList : undefined,
-            modelId: settingsStore.selectedLlmModelId,
+            modelId: llmCfg.modelId,
+            provider: llmCfg.provider,
+            azure: llmCfg.azure,
             signal: abortController?.signal,
           });
           if (isAborted.value) return;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -33,7 +33,11 @@ export type SettingsKey =
   | "soundEffectsEnabled"
   | "promptMode"
   | "audioInputDevice"
-  | "copyTranscriptionToClipboard";
+  | "copyTranscriptionToClipboard"
+  | "azureConnection"
+  | "azureChatDeployment"
+  | "azureWhisperDeployment"
+  | "whisperProvider";
 
 export interface SettingsUpdatedPayload {
   key: SettingsKey;

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -564,6 +564,128 @@ async function handleProviderChange(providerId: LlmProviderId) {
   }
 }
 
+// ── Azure / Microsoft Foundry ───────────────────────────────
+const azureFeedback = useFeedbackMessage();
+const azureEnabledInput = ref(false);
+const azureEndpointInput = ref("");
+const azureApiKeyInput = ref("");
+const azureApiVersionInput = ref("");
+const isAzureApiKeyVisible = ref(false);
+const isSubmittingAzure = ref(false);
+const azureChatDeploymentInput = ref("");
+const azureWhisperDeploymentInput = ref("");
+
+function loadAzureInputsFromStore() {
+  azureEnabledInput.value = settingsStore.azureEnabled;
+  azureEndpointInput.value = settingsStore.azureEndpoint;
+  azureApiKeyInput.value = settingsStore.azureApiKey;
+  azureApiVersionInput.value = settingsStore.azureApiVersion;
+  azureChatDeploymentInput.value = settingsStore.azureChatDeployment;
+  azureWhisperDeploymentInput.value = settingsStore.azureWhisperDeployment;
+}
+
+async function handleSaveAzureConnection() {
+  try {
+    isSubmittingAzure.value = true;
+    await settingsStore.saveAzureConnection({
+      enabled: azureEnabledInput.value,
+      endpoint: azureEndpointInput.value,
+      apiKey: azureApiKeyInput.value,
+      apiVersion: azureApiVersionInput.value,
+    });
+    azureFeedback.show("success", t("settings.azure.saved"));
+  } catch (err) {
+    azureFeedback.show("error", extractErrorMessage(err));
+  } finally {
+    isSubmittingAzure.value = false;
+  }
+}
+
+async function handleToggleAzureEnabled(value: boolean) {
+  azureEnabledInput.value = value;
+  await handleSaveAzureConnection();
+}
+
+async function handleDeleteAzureConnection() {
+  try {
+    isSubmittingAzure.value = true;
+    await settingsStore.deleteAzureConnection();
+    loadAzureInputsFromStore();
+    azureFeedback.show("success", t("settings.azure.deleted"));
+  } catch (err) {
+    azureFeedback.show("error", extractErrorMessage(err));
+  } finally {
+    isSubmittingAzure.value = false;
+  }
+}
+
+async function handleSaveAzureChatDeployment() {
+  try {
+    await settingsStore.saveAzureChatDeployment(azureChatDeploymentInput.value);
+    providerFeedback.show("success", t("settings.azure.deploymentSaved"));
+  } catch (err) {
+    providerFeedback.show("error", extractErrorMessage(err));
+  }
+}
+
+async function handleSaveAzureWhisperDeployment() {
+  try {
+    await settingsStore.saveAzureWhisperDeployment(
+      azureWhisperDeploymentInput.value,
+    );
+    modelFeedback.show("success", t("settings.azure.deploymentSaved"));
+  } catch (err) {
+    modelFeedback.show("error", extractErrorMessage(err));
+  }
+}
+
+async function handleWhisperProviderChange(id: "groq" | "azure") {
+  try {
+    await settingsStore.saveWhisperProvider(id);
+    modelFeedback.show("success", t("settings.model.whisperUpdated"));
+  } catch (err) {
+    modelFeedback.show("error", extractErrorMessage(err));
+  }
+}
+
+async function testAzureChatConnection() {
+  try {
+    const cfg = await settingsStore.getLlmRequestConfig();
+    return await testLlmConnection(cfg.modelId, cfg.apiKey, {
+      provider: cfg.provider,
+      azure: cfg.azure,
+    });
+  } catch (err) {
+    return {
+      ok: false as const,
+      durationMs: 0,
+      errorMessage: extractErrorMessage(err),
+    };
+  }
+}
+
+async function testAzureWhisperConnection() {
+  try {
+    const cfg = await settingsStore.getWhisperRequestConfig();
+    return await testWhisperConnection(
+      settingsStore.selectedWhisperModelId,
+      cfg.apiKey,
+      {
+        provider: cfg.provider,
+        endpoint: cfg.endpoint,
+        deployment: cfg.deployment,
+        apiVersion: cfg.apiVersion,
+      },
+    );
+  } catch (err) {
+    return {
+      ok: false as const,
+      durationMs: 0,
+      errorMessage: extractErrorMessage(err),
+    };
+  }
+}
+
 async function handleSaveOpenaiApiKey() {
   try {
     await settingsStore.saveOpenaiApiKey(openaiApiKeyInput.value);
@@ -843,6 +965,7 @@ onMounted(async () => {
   if (settingsStore.hasApiKey) {
     apiKeyInput.value = settingsStore.getApiKey();
   }
+  loadAzureInputsFromStore();
   thresholdEnabled.value = settingsStore.isEnhancementThresholdEnabled;
   thresholdCharCount.value = settingsStore.enhancementThresholdCharCount;
   recordingAutoCleanupEnabled.value =
@@ -874,6 +997,7 @@ onBeforeUnmount(() => {
   smartDictionaryFeedback.clearTimer();
   recordingCleanupFeedback.clearTimer();
   providerFeedback.clearTimer();
+  azureFeedback.clearTimer();
   clearTimeout(deleteConfirmTimeoutId);
   clearTimeout(resetPromptConfirmTimeoutId);
 });
@@ -1175,6 +1299,82 @@ onBeforeUnmount(() => {
       </CardContent>
     </Card>
 
+    <!-- Azure / Microsoft Foundry 連線 -->
+    <Card>
+      <CardHeader class="flex-row items-center justify-between border-b border-border">
+        <CardTitle class="text-base">{{ $t("settings.azure.title") }}</CardTitle>
+        <Switch
+          :model-value="azureEnabledInput"
+          @update:model-value="handleToggleAzureEnabled"
+        />
+      </CardHeader>
+      <CardContent v-if="azureEnabledInput" class="space-y-4">
+        <p class="text-sm text-muted-foreground leading-relaxed">
+          {{ $t("settings.azure.description") }}
+        </p>
+
+        <div class="space-y-2">
+          <Label for="azure-endpoint">{{ $t("settings.azure.endpointLabel") }}</Label>
+          <Input
+            id="azure-endpoint"
+            v-model="azureEndpointInput"
+            :placeholder="$t('settings.azure.endpointPlaceholder')"
+            class="font-mono text-xs"
+          />
+        </div>
+
+        <div class="space-y-2">
+          <Label for="azure-api-key">{{ $t("settings.azure.apiKeyLabel") }}</Label>
+          <div class="flex gap-2">
+            <Input
+              id="azure-api-key"
+              v-model="azureApiKeyInput"
+              :type="isAzureApiKeyVisible ? 'text' : 'password'"
+              class="flex-1 font-mono text-xs"
+            />
+            <Button variant="outline" size="sm" @click="isAzureApiKeyVisible = !isAzureApiKeyVisible">
+              {{ isAzureApiKeyVisible ? $t('settings.apiKey.hide') : $t('settings.apiKey.show') }}
+            </Button>
+          </div>
+        </div>
+
+        <div class="space-y-2">
+          <Label for="azure-api-version">{{ $t("settings.azure.apiVersionLabel") }}</Label>
+          <Input
+            id="azure-api-version"
+            v-model="azureApiVersionInput"
+            :placeholder="$t('settings.azure.apiVersionPlaceholder')"
+            class="font-mono text-xs"
+          />
+        </div>
+
+        <div class="flex items-center justify-between">
+          <transition name="feedback-fade">
+            <p
+              v-if="azureFeedback.message.value !== ''"
+              class="text-sm"
+              :class="azureFeedback.type.value === 'success' ? 'text-green-400' : 'text-red-400'"
+            >
+              {{ azureFeedback.message.value }}
+            </p>
+          </transition>
+          <div class="flex gap-2">
+            <Button
+              variant="outline"
+              class="text-destructive border-destructive hover:bg-destructive/10"
+              :disabled="isSubmittingAzure"
+              @click="handleDeleteAzureConnection"
+            >
+              {{ $t('settings.azure.clear') }}
+            </Button>
+            <Button :disabled="isSubmittingAzure" @click="handleSaveAzureConnection">
+              {{ $t('common.save') }}
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+
     <!-- 模型選擇 -->
     <Card>
       <CardHeader class="border-b border-border">
@@ -1188,31 +1388,81 @@ onBeforeUnmount(() => {
         <!-- Whisper 模型 -->
         <div class="space-y-2">
           <Label for="whisper-model">{{ $t("settings.model.whisperLabel") }}</Label>
-          <Select
-            :model-value="settingsStore.selectedWhisperModelId"
-            @update:model-value="handleWhisperModelChange($event as WhisperModelId)"
+
+          <!-- 轉錄 provider 切換（僅在 Azure 啟用時顯示） -->
+          <RadioGroup
+            v-if="settingsStore.azureEnabled"
+            :model-value="settingsStore.whisperProviderId"
+            class="grid grid-cols-2 gap-2"
+            @update:model-value="(v: unknown) => handleWhisperProviderChange(v as 'groq' | 'azure')"
           >
-            <SelectTrigger id="whisper-model" class="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem
-                v-for="model in WHISPER_MODEL_LIST"
-                :key="model.id"
-                :value="model.id"
-              >
-                {{ model.displayName }}
-                <template v-if="model.isDefault" #extra>
-                  <Badge variant="secondary" class="ml-2 text-xs">{{ $t("settings.model.default") }}</Badge>
-                </template>
-              </SelectItem>
-            </SelectContent>
-          </Select>
-          <p class="text-xs text-muted-foreground">{{ whisperModelDescription }}</p>
-          <ConnectionTestButton
-            :on-test="() => testWhisperConnection(settingsStore.selectedWhisperModelId, settingsStore.getApiKey())"
-            :disabled="!settingsStore.hasApiKey"
-          />
+            <Label
+              for="whisper-provider-groq"
+              class="flex cursor-pointer items-center gap-2.5 rounded-md border border-border p-3 transition-colors"
+              :class="settingsStore.whisperProviderId === 'groq' ? 'border-primary bg-primary/5' : 'hover:bg-muted/50'"
+            >
+              <RadioGroupItem id="whisper-provider-groq" value="groq" class="!size-0 !border-0 !shadow-none overflow-hidden" />
+              <span class="text-sm font-medium">Groq</span>
+            </Label>
+            <Label
+              for="whisper-provider-azure"
+              class="flex cursor-pointer items-center gap-2.5 rounded-md border border-border p-3 transition-colors"
+              :class="settingsStore.whisperProviderId === 'azure' ? 'border-primary bg-primary/5' : 'hover:bg-muted/50'"
+            >
+              <RadioGroupItem id="whisper-provider-azure" value="azure" class="!size-0 !border-0 !shadow-none overflow-hidden" />
+              <span class="text-sm font-medium">Azure</span>
+            </Label>
+          </RadioGroup>
+
+          <!-- Groq Whisper 模型下拉 -->
+          <template v-if="settingsStore.whisperProviderId === 'groq'">
+            <Select
+              :model-value="settingsStore.selectedWhisperModelId"
+              @update:model-value="handleWhisperModelChange($event as WhisperModelId)"
+            >
+              <SelectTrigger id="whisper-model" class="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem
+                  v-for="model in WHISPER_MODEL_LIST"
+                  :key="model.id"
+                  :value="model.id"
+                >
+                  {{ model.displayName }}
+                  <template v-if="model.isDefault" #extra>
+                    <Badge variant="secondary" class="ml-2 text-xs">{{ $t("settings.model.default") }}</Badge>
+                  </template>
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <p class="text-xs text-muted-foreground">{{ whisperModelDescription }}</p>
+            <ConnectionTestButton
+              :on-test="() => testWhisperConnection(settingsStore.selectedWhisperModelId, settingsStore.getApiKey())"
+              :disabled="!settingsStore.hasApiKey"
+            />
+          </template>
+
+          <!-- Azure Whisper 部署 -->
+          <template v-else>
+            <Label for="azure-whisper-deployment">{{ $t("settings.azure.whisperDeploymentLabel") }}</Label>
+            <div class="flex gap-2">
+              <Input
+                id="azure-whisper-deployment"
+                v-model="azureWhisperDeploymentInput"
+                :placeholder="$t('settings.azure.whisperDeploymentPlaceholder')"
+                class="flex-1 font-mono text-xs"
+              />
+              <Button size="sm" :disabled="!azureWhisperDeploymentInput.trim()" @click="handleSaveAzureWhisperDeployment">
+                {{ $t('common.save') }}
+              </Button>
+            </div>
+            <p class="text-xs text-muted-foreground">{{ $t("settings.azure.whisperHint") }}</p>
+            <ConnectionTestButton
+              :on-test="testAzureWhisperConnection"
+              :disabled="!settingsStore.hasWhisperConfig"
+            />
+          </template>
         </div>
 
         <Separator />
@@ -1349,8 +1599,27 @@ onBeforeUnmount(() => {
           </p>
         </div>
 
+        <div v-else-if="settingsStore.selectedLlmProviderId === 'azure'" class="space-y-2">
+          <Label for="azure-chat-deployment">{{ $t("settings.azure.chatDeploymentLabel") }}</Label>
+          <div class="flex gap-2">
+            <Input
+              id="azure-chat-deployment"
+              v-model="azureChatDeploymentInput"
+              :placeholder="$t('settings.azure.chatDeploymentPlaceholder')"
+              class="flex-1 font-mono text-xs"
+            />
+            <Button size="sm" :disabled="!azureChatDeploymentInput.trim()" @click="handleSaveAzureChatDeployment">
+              {{ $t('common.save') }}
+            </Button>
+          </div>
+          <p v-if="!settingsStore.azureEnabled" class="text-xs text-amber-400">
+            {{ $t("settings.azure.notConfiguredHint") }}
+          </p>
+          <p v-else class="text-xs text-muted-foreground">{{ $t("settings.azure.chatHint") }}</p>
+        </div>
+
         <ConnectionTestButton
-          :on-test="() => testLlmConnection(settingsStore.selectedLlmModelId, settingsStore.getLlmApiKey())"
+          :on-test="settingsStore.selectedLlmProviderId === 'azure' ? testAzureChatConnection : () => testLlmConnection(settingsStore.selectedLlmModelId, settingsStore.getLlmApiKey())"
           :disabled="!settingsStore.hasLlmApiKey"
         />
 
@@ -1364,7 +1633,7 @@ onBeforeUnmount(() => {
           </p>
         </transition>
 
-        <template v-if="settingsStore.selectedLlmProviderId === 'groq' || settingsStore.hasLlmApiKey">
+        <template v-if="settingsStore.selectedLlmProviderId !== 'azure' && (settingsStore.selectedLlmProviderId === 'groq' || settingsStore.hasLlmApiKey)">
           <Separator />
 
           <!-- LLM 模型 -->

--- a/tests/unit/azureProvider.test.ts
+++ b/tests/unit/azureProvider.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildFetchParams,
+  normalizeAzureEndpoint,
+  parseProviderResponse,
+  type LlmChatRequest,
+  type AzureRequestOptions,
+} from "../../src/lib/llmProvider";
+
+const REQUEST: LlmChatRequest = {
+  model: "my-gpt4o-deployment",
+  messages: [
+    { role: "system", content: "sys" },
+    { role: "user", content: "hi" },
+  ],
+  temperature: 0.1,
+  maxTokens: 1024,
+};
+
+describe("Azure provider", () => {
+  describe("normalizeAzureEndpoint", () => {
+    it("[P1] 去尾斜線", () => {
+      expect(normalizeAzureEndpoint("https://r.openai.azure.com/")).toBe(
+        "https://r.openai.azure.com",
+      );
+    });
+
+    it("[P1] 去掉多餘的 /openai/v1/chat/completions", () => {
+      expect(
+        normalizeAzureEndpoint(
+          "https://r.openai.azure.com/openai/v1/chat/completions",
+        ),
+      ).toBe("https://r.openai.azure.com");
+    });
+
+    it("[P1] 去掉 /openai 與 /openai/v1", () => {
+      expect(normalizeAzureEndpoint("https://r.openai.azure.com/openai")).toBe(
+        "https://r.openai.azure.com",
+      );
+      expect(
+        normalizeAzureEndpoint("https://r.services.ai.azure.com/openai/v1"),
+      ).toBe("https://r.services.ai.azure.com");
+    });
+
+    it("[P1] 去掉含 query string 的完整 URL", () => {
+      expect(
+        normalizeAzureEndpoint(
+          "https://r.openai.azure.com/openai/deployments/x/chat/completions?api-version=2024-10-21",
+        ),
+      ).toBe("https://r.openai.azure.com");
+    });
+  });
+
+  describe("buildFetchParams azure", () => {
+    it("[P0] uses v1 URL, api-key header, deployment model, and max_completion_tokens", () => {
+      const azure: AzureRequestOptions = {
+        endpoint: "https://r.openai.azure.com",
+        apiKey: "azkey",
+      };
+      const { url, init } = buildFetchParams("azure", REQUEST, "", azure);
+
+      expect(url).toBe(
+        "https://r.openai.azure.com/openai/v1/chat/completions",
+      );
+      const headers = init.headers as Record<string, string>;
+      expect(headers["api-key"]).toBe("azkey");
+      expect(headers.Authorization).toBeUndefined();
+
+      const body = JSON.parse(init.body as string);
+      expect(body.model).toBe("my-gpt4o-deployment");
+      expect(body.max_completion_tokens).toBe(1024);
+      expect(body.max_tokens).toBeUndefined();
+    });
+
+    it("[P1] apiVersion 帶入 query string", () => {
+      const azure: AzureRequestOptions = {
+        endpoint: "https://r.openai.azure.com",
+        apiVersion: "preview",
+        apiKey: "k",
+      };
+      const { url } = buildFetchParams("azure", REQUEST, "", azure);
+      expect(url).toBe(
+        "https://r.openai.azure.com/openai/v1/chat/completions?api-version=preview",
+      );
+    });
+
+    it("[P1] 缺 azureOptions 時拋錯", () => {
+      expect(() => buildFetchParams("azure", REQUEST, "")).toThrow();
+    });
+
+    it("[P1] 回應走 OpenAI-compatible 解析（無 groq 計時欄位）", () => {
+      const result = parseProviderResponse("azure", {
+        choices: [{ message: { content: "  hello  " } }],
+        usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 },
+      });
+      expect(result.text).toBe("hello");
+      expect(result.usage?.totalTokens).toBe(5);
+      expect(result.usage?.promptTimeMs).toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/use-voice-flow-store.test.ts
+++ b/tests/unit/use-voice-flow-store.test.ts
@@ -176,6 +176,17 @@ vi.mock("../../src/stores/useSettingsStore", () => ({
     loadSettings: mockLoadSettings,
     getApiKey: () => mockSettingsState.apiKey,
     getLlmApiKey: () => mockSettingsState.apiKey,
+    getLlmRequestConfig: () =>
+      Promise.resolve({
+        apiKey: mockSettingsState.apiKey,
+        provider: "groq",
+        modelId: mockSettingsState.selectedLlmModelId,
+      }),
+    getWhisperRequestConfig: () =>
+      Promise.resolve({ apiKey: mockSettingsState.apiKey, provider: "groq" }),
+    getEffectiveChatModel: () => mockSettingsState.selectedLlmModelId,
+    whisperProviderId: "groq",
+    hasWhisperConfig: true,
     getAiPrompt: () => mockSettingsState.aiPrompt,
     refreshApiKey: vi.fn().mockResolvedValue(undefined),
     refreshLlmApiKey: vi.fn().mockResolvedValue(undefined),
@@ -449,6 +460,10 @@ describe("useVoiceFlowStore", () => {
       vocabularyTermList: null,
       modelId: "whisper-large-v3",
       language: "zh",
+      provider: "groq",
+      endpoint: null,
+      deployment: null,
+      apiVersion: null,
     });
     expect(store.status).toBe("success");
     expect(store.message).toBe("voiceFlow.pasteSuccess");
@@ -675,7 +690,7 @@ describe("useVoiceFlowStore", () => {
   it("[P0] 轉錄失敗時應回報中文錯誤訊息", async () => {
     mockInvoke.mockImplementation(
       createMockInvokeHandler({
-        transcribeError: new Error("Groq API error (500)"),
+        transcribeError: new Error("Transcription API error (500)"),
       }),
     );
 
@@ -1310,7 +1325,11 @@ describe("useVoiceFlowStore", () => {
         vocabularyTermList: ["TypeScript", "Tauri"],
         modelId: "whisper-large-v3",
         language: "zh",
-      });
+        provider: "groq",
+        endpoint: null,
+        deployment: null,
+        apiVersion: null,
+        });
     });
 
     it("[P0] 空詞彙時應傳 null 給 transcribe_audio", async () => {
@@ -1339,7 +1358,11 @@ describe("useVoiceFlowStore", () => {
         vocabularyTermList: null,
         modelId: "whisper-large-v3",
         language: "zh",
-      });
+        provider: "groq",
+        endpoint: null,
+        deployment: null,
+        apiVersion: null,
+        });
     });
 
     it("[P0] 詞彙清單應同時傳給 transcriber 和 enhancer", async () => {
@@ -1400,7 +1423,11 @@ describe("useVoiceFlowStore", () => {
         vocabularyTermList: ["Pinia", "Vitest"],
         modelId: "whisper-large-v3",
         language: "zh",
-      });
+        provider: "groq",
+        endpoint: null,
+        deployment: null,
+        apiVersion: null,
+        });
 
       // enhancer 也收到詞彙
       expect(mockEnhanceText).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

This is split PR ① of 4 replacing stacked PR #46:

1. **Azure / Microsoft Foundry provider — API-key auth only** (this PR)
2. Dashboard usage / billed provider changes (#62)
3. Rustls transcription client change (#63)
4. Clippy cleanup (#57)

This PR adds Azure OpenAI / Microsoft Foundry provider support with **API-Key auth only**. Entra ID client-credentials authentication has been removed per the maintainer's request on #46.

## Changes

- Add Azure / Microsoft Foundry chat enhancement via `{endpoint}/openai/v1/chat/completions` using the `api-key` header.
- Add Azure Whisper transcription via `{endpoint}/openai/deployments/{deployment}/audio/transcriptions?api-version=...` using the `api-key` header.
- Add endpoint normalization, Azure model/provider wiring, settings UI fields, and connection tests.
- Add Azure host allowlist/CSP entries for `*.openai.azure.com`, `*.services.ai.azure.com`, and `*.cognitiveservices.azure.com`.
- Add i18n coverage for zh-TW, zh-CN, en, ja, and ko.
- Exclude Entra ID auth, rustls changes, Dashboard usage changes, and clippy cleanup.

Closes #45
